### PR TITLE
Additional type conversions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,9 @@ rocksdb = { version = "0.22.0", default-features = true, features = ["snappy"] }
 rusqlite = { version = "0.32.1", features = [
     "backup",
     "bundled",
+    "chrono",
     "column_decltype",
+    "serde_json",
 ] }
 rust-embed = { version = "8.5.0", features = [] }
 rustls = { version = "0.23.12", features = ["ring"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ chrono = { version = "0.4.38", default-features = false, features = [
     "std",
     "clock",
     "now",
+    #    "serde",
 ] }
 clap = { version = "4.1.11", features = ["derive", "env"] }
 cron = { version = "0.12.1" }

--- a/dashboard/src/lib/stores/sharedRune.svelte.ts
+++ b/dashboard/src/lib/stores/sharedRune.svelte.ts
@@ -13,12 +13,6 @@ export const useSharedStore = <T, A>(
     return _value;
 };
 
-// export const useWritable = <T>(name: string, value?: T) =>
-//     useSharedStore(name, writable, value);
-//
-// export const useReadable = <T>(name: string, value: T) =>
-//     useSharedStore(name, readable, value);
-
 export const useSignal = <T>(name: string, value: T) =>
     useSharedStore(name, signal, value);
 

--- a/hiqlite/src/query/rows.rs
+++ b/hiqlite/src/query/rows.rs
@@ -443,12 +443,11 @@ impl TryFrom<ValueOwned> for DateTime<FixedOffset> {
 impl TryFrom<ValueOwned> for serde_json::Value {
     type Error = crate::Error;
 
-    /// RFC3339 ("YYYY-MM-DD HH:MM:SS.SSS[+-]HH:MM") into `DateTime<Local>`.
     fn try_from(value: ValueOwned) -> Result<Self, Self::Error> {
         let slf = match value {
             ValueOwned::Null => serde_json::Value::Null,
-            ValueOwned::Integer(i) => serde_json::Value::Number(i.into()),
-            ValueOwned::Real(r) => serde_json::Value::Number(r.into()),
+            ValueOwned::Integer(i) => serde_json::Value::from(i),
+            ValueOwned::Real(r) => serde_json::Value::from(r),
             ValueOwned::Text(s) => serde_json::from_str(s.as_str())
                 .map_err(|err| Error::Sqlite(err.to_string().into()))?,
             ValueOwned::Blob(b) => {

--- a/hiqlite/src/query/rows.rs
+++ b/hiqlite/src/query/rows.rs
@@ -439,3 +439,22 @@ impl TryFrom<ValueOwned> for DateTime<FixedOffset> {
             .map_err(|err| Error::Sqlite(err.to_string().into()))
     }
 }
+
+impl TryFrom<ValueOwned> for serde_json::Value {
+    type Error = crate::Error;
+
+    /// RFC3339 ("YYYY-MM-DD HH:MM:SS.SSS[+-]HH:MM") into `DateTime<Local>`.
+    fn try_from(value: ValueOwned) -> Result<Self, Self::Error> {
+        let slf = match value {
+            ValueOwned::Null => serde_json::Value::Null,
+            ValueOwned::Integer(i) => serde_json::Value::Number(i.into()),
+            ValueOwned::Real(r) => serde_json::Value::Number(r.into()),
+            ValueOwned::Text(s) => serde_json::from_str(s.as_str())
+                .map_err(|err| Error::Sqlite(err.to_string().into()))?,
+            ValueOwned::Blob(b) => {
+                serde_json::from_slice(&b).map_err(|err| Error::Sqlite(err.to_string().into()))?
+            }
+        };
+        Ok(slf)
+    }
+}

--- a/hiqlite/src/split_brain_check.rs
+++ b/hiqlite/src/split_brain_check.rs
@@ -5,7 +5,7 @@ use openraft::{RaftMetrics, StoredMembership};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::{task, time};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, warn};
 
 pub fn spawn(state: Arc<AppState>, nodes: Vec<Node>, tls: bool) {
     let handle = task::spawn(check_split_brain(state, nodes, tls));

--- a/hiqlite/src/split_brain_check.rs
+++ b/hiqlite/src/split_brain_check.rs
@@ -5,7 +5,7 @@ use openraft::{RaftMetrics, StoredMembership};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::{task, time};
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 pub fn spawn(state: Arc<AppState>, nodes: Vec<Node>, tls: bool) {
     let handle = task::spawn(check_split_brain(state, nodes, tls));
@@ -46,7 +46,7 @@ async fn check_split_brain(state: Arc<AppState>, nodes: Vec<Node>, tls: bool) {
                 {
                     error!("Error during check_compare_membership: {}", err);
                 } else {
-                    info!("Raft DB Leader: {}", leader_expected);
+                    debug!("Raft DB Leader: {}", leader_expected);
                 }
             }
         };
@@ -73,7 +73,7 @@ async fn check_split_brain(state: Arc<AppState>, nodes: Vec<Node>, tls: bool) {
                 {
                     error!("Error during check_compare_membership: {}", err);
                 } else {
-                    info!("Raft Cache Leader: {}", leader_expected);
+                    debug!("Raft Cache Leader: {}", leader_expected);
                 }
             }
         };

--- a/hiqlite/src/store/state_machine/sqlite/param.rs
+++ b/hiqlite/src/store/state_machine/sqlite/param.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, FixedOffset, Local, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use rusqlite::types::{ToSqlOutput, Value};
 use serde::{Deserialize, Serialize};
 
@@ -138,6 +139,65 @@ impl From<Vec<u8>> for Param {
     #[inline]
     fn from(v: Vec<u8>) -> Param {
         Param::Blob(v)
+    }
+}
+
+impl From<DateTime<Utc>> for Param {
+    /// UTC time => UTC RFC3339 timestamp
+    /// ("YYYY-MM-DD HH:MM:SS.SSS+00:00")
+    #[inline]
+    fn from(value: DateTime<Utc>) -> Self {
+        Param::Text(value.format("%F %T%.f%:z").to_string())
+    }
+}
+
+impl From<DateTime<Local>> for Param {
+    /// Local time => UTC RFC3339 timestamp
+    /// ("YYYY-MM-DD HH:MM:SS.SSS+00:00")
+    #[inline]
+    fn from(value: DateTime<Local>) -> Self {
+        Param::Text(value.with_timezone(&Utc).format("%F %T%.f%:z").to_string())
+    }
+}
+
+impl From<DateTime<FixedOffset>> for Param {
+    /// Date and time with time zone => RFC3339 timestamp
+    /// ("YYYY-MM-DD HH:MM:SS.SSS[+-]HH:MM")
+    #[inline]
+    fn from(value: DateTime<FixedOffset>) -> Self {
+        Param::Text(value.format("%F %T%.f%:z").to_string())
+    }
+}
+
+impl From<NaiveDate> for Param {
+    /// ISO 8601 calendar date without timezone => "YYYY-MM-DD"
+    #[inline]
+    fn from(value: NaiveDate) -> Self {
+        Param::Text(value.format("%F").to_string())
+    }
+}
+
+impl From<NaiveTime> for Param {
+    /// ISO 8601 time without timezone => "HH:MM:SS.SSS"
+    #[inline]
+    fn from(value: NaiveTime) -> Self {
+        Param::Text(value.format("%T%.f").to_string())
+    }
+}
+
+impl From<NaiveDateTime> for Param {
+    /// ISO 8601 combined date and time without timezone =>
+    /// "YYYY-MM-DD HH:MM:SS.SSS"
+    #[inline]
+    fn from(value: NaiveDateTime) -> Self {
+        Param::Text(value.format("%F %T%.f").to_string())
+    }
+}
+
+impl From<serde_json::Value> for Param {
+    #[inline]
+    fn from(value: serde_json::Value) -> Self {
+        Param::Text(value.to_string())
     }
 }
 

--- a/hiqlite/tests/cluster/main.rs
+++ b/hiqlite/tests/cluster/main.rs
@@ -22,6 +22,7 @@ mod cache;
 mod dlock;
 mod listen_notify;
 mod remote_only;
+mod type_conversions;
 
 pub const TEST_DATA_DIR: &str = "tests/data_test";
 
@@ -85,6 +86,10 @@ async fn exec_tests() -> Result<(), Error> {
     log("Starting batch tests");
     batch::test_batch(&client_1, &client_2, &client_3).await?;
     log("Batch tests finished");
+
+    log("Starting SQL type conversion tests");
+    type_conversions::test_type_conversions(&client_1).await?;
+    log("SQL type conversion tests finished");
 
     log("Test cache operations");
     cache::test_cache(&client_1, &client_2, &client_3).await?;

--- a/hiqlite/tests/cluster/migration.rs
+++ b/hiqlite/tests/cluster/migration.rs
@@ -94,7 +94,7 @@ async fn test_migrations_are_correct(client: &Client) -> Result<(), Error> {
     let migrations: Vec<AppliedMigration> = client
         .query_map("SELECT * FROM _migrations", params!())
         .await?;
-    assert_eq!(migrations.len(), 2);
+    assert_eq!(migrations.len(), 3);
     debug(&migrations);
 
     assert_eq!(migrations[0].id, 1);
@@ -110,6 +110,9 @@ async fn test_migrations_are_correct(client: &Client) -> Result<(), Error> {
         migrations[1].hash,
         "c61c731c49a33a44ad56112365423f8d654e7ddbe9320f2492746aa61f54a733"
     );
+
+    assert_eq!(migrations[2].id, 3);
+    assert_eq!(migrations[2].name, "types_conversion");
 
     Ok(())
 }

--- a/hiqlite/tests/cluster/migrations/good/3_types_conversion.sql
+++ b/hiqlite/tests/cluster/migrations/good/3_types_conversion.sql
@@ -1,0 +1,19 @@
+CREATE TABLE type_conversion
+(
+    id         INTEGER NOT NULL
+        CONSTRAINT type_conversion_pk
+            PRIMARY KEY,
+    id_none    INTEGER,
+    id_opt     INTEGER,
+    name       TEXT    NOT NULL,
+    name_none  TEXT,
+    name_opt   TEXT,
+    is_bool    INTEGER NOT NULL,
+    utc        TEXT    NOT NULL,
+    local      TEXT    NOT NULL,
+    offset     TEXT    NOT NULL,
+    naive_date TEXT    NOT NULL,
+    naive_time TEXT    NOT NULL,
+    naive_dt   TEXT    NOT NULL,
+    json       TEXT    NOT NULL
+);

--- a/hiqlite/tests/cluster/type_conversions.rs
+++ b/hiqlite/tests/cluster/type_conversions.rs
@@ -1,0 +1,136 @@
+use crate::debug;
+use chrono::{DateTime, FixedOffset, Local, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+use hiqlite::{params, Client, Error, Param, Row};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq)]
+struct Data {
+    id: i64,
+    id_none: Option<i64>,
+    id_opt: Option<i64>,
+    name: String,
+    name_none: Option<String>,
+    name_opt: Option<String>,
+    is_bool: bool,
+    utc: DateTime<Utc>,
+    local: DateTime<Local>,
+    offset: DateTime<FixedOffset>,
+    naive_date: NaiveDate,
+    naive_time: NaiveTime,
+    naive_dt: NaiveDateTime,
+    json: serde_json::Value,
+}
+
+impl<'r> From<hiqlite::Row<'r>> for Data {
+    fn from(mut row: Row) -> Self {
+        Self {
+            id: row.get("id"),
+            id_none: row.get("id_none"),
+            id_opt: row.get("id_opt"),
+            name: row.get("name"),
+            name_none: row.get("name_none"),
+            name_opt: row.get("name_opt"),
+            is_bool: row.get("is_bool"),
+            utc: row.get("utc"),
+            local: row.get("local"),
+            offset: row.get("offset"),
+            naive_date: row.get("naive_date"),
+            naive_time: row.get("naive_time"),
+            naive_dt: row.get("naive_dt"),
+            json: row.get("json"),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Json {
+    id: i64,
+    text: String,
+}
+
+pub async fn test_type_conversions(client: &Client) -> Result<(), Error> {
+    let utc = Utc::now();
+    let local = Local::now();
+    let offset = utc.fixed_offset();
+
+    let naive_dt = utc.naive_local();
+    let naive_date = utc.date_naive();
+    let naive_time = naive_dt.time();
+
+    let mut json_map = serde_json::Map::new();
+    json_map.insert("id".to_string(), serde_json::Value::from(23));
+    json_map.insert(
+        "text".to_string(),
+        serde_json::Value::from("Some Json Text"),
+    );
+
+    let data = Data {
+        id: 1,
+        id_none: None,
+        id_opt: Some(2),
+        name: "Name".to_string(),
+        name_none: None,
+        name_opt: Some("Some Name".to_string()),
+        is_bool: true,
+        utc,
+        local,
+        offset,
+        naive_date,
+        naive_time,
+        naive_dt,
+        json: serde_json::Value::Object(json_map.clone()),
+    };
+    debug(&data);
+
+    let d = data.clone();
+    let params = params!(
+        d.id,
+        d.id_none,
+        d.id_opt,
+        d.name,
+        d.name_none,
+        d.name_opt,
+        d.is_bool,
+        d.utc,
+        d.local,
+        d.offset,
+        d.naive_date,
+        d.naive_time,
+        d.naive_dt,
+        d.json
+    );
+    debug(&params);
+
+    let ret: Vec<Data> = client
+        .execute_returning_map(
+            r#"INSERT INTO type_conversion
+            (id, id_none, id_opt, name, name_none, name_opt, is_bool, utc, local, offset,
+            naive_date, naive_time, naive_dt, json)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+            RETURNING *"#,
+            params,
+        )
+        .await?;
+    assert_eq!(ret.len(), 1);
+    assert_eq!(ret[0], data);
+
+    let slf: Data = client
+        .query_map_one(
+            "SELECT * FROM type_conversion WHERE id = $1",
+            params!(data.id),
+        )
+        .await?;
+    assert_eq!(slf, data);
+
+    // TODO we can't use the automatic conversion with `query_as`, because the default serialization
+    // / deserialization for chrono types is not the one implemented in rusqlite. Can we make this work?
+    // let slf: Data = client
+    //     .query_as_one(
+    //         "SELECT * FROM type_conversion WHERE id = $1",
+    //         params!(data.id),
+    //     )
+    //     .await?;
+    // assert_eq!(slf, data);
+
+    Ok(())
+}


### PR DESCRIPTION
This adds support for the following types via `To<_>` and `From<_>` impls:

- `bool`
- chrono:
    - `NaiveDate`
    - `NaiveTime`
    - `NaiveDateTime`
    - `DateTime<Utc>`
    - `DateTime<Local>`
    - `DateTime<FixedOffset>`
- `serde_json::Value`

The `chrono` conversions currently only work with `query_map` functions, not with the `*_as` versions, because the default impl for `serde::Serialize` does not match the implementation in `rusqlite` with the feature `chrono`.