### PR TITLE
Migration optimizations

### DIFF
--- a/dashboard/src/lib/components/Login.svelte
+++ b/dashboard/src/lib/components/Login.svelte
@@ -100,6 +100,7 @@
 
 <style>
     .container {
+        width: 100dvw;
         flex: 1;
         display: flex;
         justify-content: center;

--- a/dashboard/src/lib/components/form/Form.svelte
+++ b/dashboard/src/lib/components/form/Form.svelte
@@ -60,6 +60,6 @@
     }
 </script>
 
-<form action={action} method={method} onsubmit={submit}>
+<form {action} {method} onsubmit={submit}>
     {@render children()}
 </form>

--- a/dashboard/src/lib/components/query/ResultsDataTable.svelte
+++ b/dashboard/src/lib/components/query/ResultsDataTable.svelte
@@ -17,7 +17,8 @@
             for (let col of rows[0].columns) {
                 cols.push({
                     content: col.name,
-                    initialWidth: `${5 + col.name.length * .5}rem`,
+                    initialWidth: '12rem',
+                    // initialWidth: `${8 + col.name.length * .5}rem`,
                     orderType: columnOrderType(col.value),
                 })
             }


### PR DESCRIPTION
This PR will compare and reduce new migrations with already applied ones to reduce payloads being sent over the Raft when a client just restarts. The client will now exit early, if there is nothing left to do and not even bother with sending the request. This reduces the Raft logs by quite a bit if you have application frequent restarts.