### PR TITLE
fix: return inner `Result<_>`s when using `Client::execute_returning()`

### DIFF
--- a/hiqlite/src/network/api.rs
+++ b/hiqlite/src/network/api.rs
@@ -317,7 +317,7 @@ pub(crate) enum ApiStreamResponsePayload {
     #[cfg(feature = "sqlite")]
     Execute(Result<usize, Error>),
     #[cfg(feature = "sqlite")]
-    ExecuteReturning(Result<Vec<RowOwned>, Error>),
+    ExecuteReturning(Result<Vec<Result<RowOwned, Error>>, Error>),
     #[cfg(feature = "sqlite")]
     Transaction(Result<Vec<Result<usize, Error>>, Error>),
     #[cfg(feature = "sqlite")]

--- a/hiqlite/src/store/state_machine/sqlite/state_machine.rs
+++ b/hiqlite/src/store/state_machine/sqlite/state_machine.rs
@@ -77,7 +77,7 @@ pub struct ResponseExecute {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ResponseExecuteReturning {
-    pub result: Result<Vec<RowOwned>, Error>,
+    pub result: Result<Vec<Result<RowOwned, Error>>, Error>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/hiqlite/tests/cluster/execute_query.rs
+++ b/hiqlite/tests/cluster/execute_query.rs
@@ -185,10 +185,11 @@ pub async fn test_execute_query(
         )
         .await?;
     assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0].get::<i64>("id"), data.id);
-    assert_eq!(rows[0].get::<i64>("ts"), data.ts);
+    let mut row = rows.remove(0)?;
+    assert_eq!(row.get::<i64>("id"), data.id);
+    assert_eq!(row.get::<i64>("ts"), data.ts);
     assert_eq!(
-        rows[0].get::<Option<String>>("description").as_deref(),
+        row.get::<Option<String>>("description").as_deref(),
         Some("Execute Returning Data")
     );
 
@@ -198,16 +199,17 @@ pub async fn test_execute_query(
         ts: Utc::now().timestamp(),
         description: None,
     };
-    let rows: Vec<TestData> = client_1
+    let mut rows: Vec<Result<TestData, Error>> = client_1
         .execute_returning_map(
             "INSERT INTO test VALUES ($1, $2, $3) RETURNING *",
             params!(data.id, data.ts, data.description.clone()),
         )
         .await?;
     assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0].id, data.id);
-    assert_eq!(rows[0].ts, data.ts);
-    assert_eq!(rows[0].description, data.description);
+    let row = rows.remove(0)?;
+    assert_eq!(row.id, data.id);
+    assert_eq!(row.ts, data.ts);
+    assert_eq!(row.description, data.description);
 
     Ok(())
 }

--- a/hiqlite/tests/cluster/type_conversions.rs
+++ b/hiqlite/tests/cluster/type_conversions.rs
@@ -101,7 +101,7 @@ pub async fn test_type_conversions(client: &Client) -> Result<(), Error> {
     );
     debug(&params);
 
-    let ret: Vec<Data> = client
+    let mut ret: Vec<Result<Data, Error>> = client
         .execute_returning_map(
             r#"INSERT INTO type_conversion
             (id, id_none, id_opt, name, name_none, name_opt, is_bool, utc, local, offset,
@@ -112,7 +112,8 @@ pub async fn test_type_conversions(client: &Client) -> Result<(), Error> {
         )
         .await?;
     assert_eq!(ret.len(), 1);
-    assert_eq!(ret[0], data);
+    let res: Data = ret.remove(0)?;
+    assert_eq!(res, data);
 
     let slf: Data = client
         .query_map_one(
@@ -122,7 +123,7 @@ pub async fn test_type_conversions(client: &Client) -> Result<(), Error> {
         .await?;
     assert_eq!(slf, data);
 
-    // TODO we can't use the automatic conversion with `query_as`, because the default serialization
+    // TODO we can't use the automatic conversion with `query_as`, because of the default serialization
     // / deserialization for chrono types is not the one implemented in rusqlite. Can we make this work?
     // let slf: Data = client
     //     .query_as_one(


### PR DESCRIPTION
This changes the return type for `Client::execute_returning()` and `Client::execute_returning_map()`, which now will include the inner `Result`s of each single query.