### PR TITLE
exit early on `batch` error and wrap inside `txn`

### DIFF
--- a/hiqlite/src/client/batch.rs
+++ b/hiqlite/src/client/batch.rs
@@ -65,7 +65,7 @@ impl Client {
                 .await?;
             let resp: Response = res.data;
             match resp {
-                Response::Batch(res) => Ok(res.result),
+                Response::Batch(res) => res.result,
                 _ => unreachable!(),
             }
         } else {

--- a/hiqlite/src/client/mgmt.rs
+++ b/hiqlite/src/client/mgmt.rs
@@ -169,12 +169,11 @@ impl Client {
                     let (tx, rx) = tokio::sync::oneshot::channel();
 
                     info!("Shutting down sqlite writer");
-                    state
+                    let _ = state
                         .raft_db
                         .sql_writer
                         .send_async(WriterRequest::Shutdown(tx))
-                        .await
-                        .expect("SQL writer to always be running");
+                        .await;
 
                     info!("Shutting down sqlite logs writer");
                     if state
@@ -202,7 +201,7 @@ impl Client {
         let _ = tx_client_cache.send_async(ClientStreamReq::Shutdown).await;
 
         if let Some(tx) = tx_shutdown {
-            tx.send(true).unwrap();
+            let _ = tx.send(true);
         }
 
         info!("Waiting 5 additional seconds before shutting down");

--- a/hiqlite/src/network/api.rs
+++ b/hiqlite/src/network/api.rs
@@ -600,7 +600,7 @@ async fn handle_socket_concurrent(
                             };
                             ApiStreamResponse {
                                 request_id,
-                                result: ApiStreamResponsePayload::Batch(Ok(res.result)),
+                                result: ApiStreamResponsePayload::Batch(res.result),
                             }
                         }
                         Err(err) => ApiStreamResponse {

--- a/hiqlite/src/store/state_machine/sqlite/state_machine.rs
+++ b/hiqlite/src/store/state_machine/sqlite/state_machine.rs
@@ -82,7 +82,7 @@ pub struct ResponseExecuteReturning {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ResponseBatch {
-    pub result: Vec<Result<usize, Error>>,
+    pub result: Result<Vec<Result<usize, Error>>, Error>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/hiqlite/tests/cluster/self_heal.rs
+++ b/hiqlite/tests/cluster/self_heal.rs
@@ -138,9 +138,9 @@ pub async fn test_self_healing(
     }
 
     // since we took ownership, we need to shut down the clients here
-    // client_1.shutdown().await?;
+    client_1.shutdown().await?;
     log("client_1 shutdown complete after self heal tests");
-    // client_2.shutdown().await?;
+    client_2.shutdown().await?;
     log("client_2 shutdown complete after self heal tests");
     client_3.shutdown().await?;
     log("client_3 shutdown complete after self heal tests");


### PR DESCRIPTION
The `rusqlite` `Batch` stream can't recover from errors because of the internal design.  
We need to exit and error early instead of trying to execute queries after one with a syntax error.