### PR TITLE
feat: make the dashboard optional even with enabled feature

### DIFF
--- a/hiqlite/src/config.rs
+++ b/hiqlite/src/config.rs
@@ -62,7 +62,7 @@ pub struct NodeConfig {
     pub s3_config: Option<std::sync::Arc<crate::s3::S3Config>>,
     /// Set the password for the integrated dashboard. Must be given as argon2id hash. feature `dashboard`
     #[cfg(feature = "dashboard")]
-    pub password_dashboard: String,
+    pub password_dashboard: Option<String>,
 }
 
 impl Default for NodeConfig {
@@ -85,7 +85,7 @@ impl Default for NodeConfig {
             #[cfg(feature = "s3")]
             s3_config: None,
             #[cfg(feature = "dashboard")]
-            password_dashboard: String::default(),
+            password_dashboard: None,
             // #[cfg(feature = "dashboard")]
             // insecure_cookie: false,
         }
@@ -240,10 +240,12 @@ impl NodeConfig {
         }
 
         #[cfg(feature = "dashboard")]
-        if self.password_dashboard.len() < 14 {
-            return Err(Error::Config(
-                "password_dashboard should be at least 14 characters long".into(),
-            ));
+        if let Some(pwd) = &self.password_dashboard {
+            if pwd.len() < 16 {
+                return Err(Error::Config(
+                    "password_dashboard should be at least 14 characters long".into(),
+                ));
+            }
         }
 
         Ok(())

--- a/hiqlite/src/dashboard/mod.rs
+++ b/hiqlite/src/dashboard/mod.rs
@@ -4,6 +4,7 @@ use cryptr::EncKeys;
 use spow::pow::Pow;
 use std::env;
 use std::fmt::Debug;
+use tracing::warn;
 
 pub mod handlers;
 pub mod middleware;
@@ -15,16 +16,25 @@ mod table;
 
 #[derive(Debug)]
 pub struct DashboardState {
-    pub password_dashboard: String,
+    pub password_dashboard: Option<String>,
 }
 
 impl DashboardState {
     pub fn from_env() -> Self {
-        let b64 =
-            env::var("HQL_PASSWORD_DASHBOARD").expect("HQL_PASSWORD_DASHBOARD does not exist");
-        let password_dashboard = String::from_utf8(b64_decode(&b64).unwrap()).unwrap();
-
-        Self { password_dashboard }
+        match env::var("HQL_PASSWORD_DASHBOARD") {
+            Ok(b64) => {
+                let hash = String::from_utf8(b64_decode(&b64).unwrap()).unwrap();
+                Self {
+                    password_dashboard: Some(hash),
+                }
+            }
+            Err(_) => {
+                warn!("HQL_PASSWORD_DASHBOARD has not been set and the dashboard will be disabled");
+                Self {
+                    password_dashboard: None,
+                }
+            }
+        }
     }
 }
 

--- a/hiqlite/src/dashboard/password.rs
+++ b/hiqlite/src/dashboard/password.rs
@@ -1,13 +1,23 @@
 use crate::Error;
 use argon2::{Argon2, PasswordHash, PasswordVerifier};
+use std::sync::LazyLock;
+use tokio::sync::RwLock;
 use tokio::task;
 
+// very simple way to rate-limit password hashing / login.
+// only a single password hash at a time is allowed, the dashboard is just for debugging.
+// prevents brute-fore effectively.
+static IS_HASHING: LazyLock<RwLock<()>> = LazyLock::new(|| RwLock::new(()));
+
 pub async fn verify_password(plain: String, hash: String) -> Result<(), Error> {
+    let _ = IS_HASHING.write().await;
+
     task::spawn_blocking(move || {
         let parsed_hash = PasswordHash::new(&hash)?;
         Argon2::default().verify_password(plain.as_bytes(), &parsed_hash)?;
         Ok::<(), Error>(())
     })
     .await??;
+
     Ok(())
 }

--- a/hiqlite/src/dashboard/session.rs
+++ b/hiqlite/src/dashboard/session.rs
@@ -132,11 +132,15 @@ pub async fn set_session_verify(
     password: String,
 ) -> Result<Response, Error> {
     check_csrf(&method, headers).await?;
-    password::verify_password(password, state.dashboard.password_dashboard.clone()).await?;
+    if let Some(pwd) = state.dashboard.password_dashboard.clone() {
+        password::verify_password(password, pwd).await?;
 
-    let session = Session::new();
-    let cookie = session.as_cookie()?;
-    Ok(([(SET_COOKIE, cookie)], Json(session)).into_response())
+        let session = Session::new();
+        let cookie = session.as_cookie()?;
+        Ok(([(SET_COOKIE, cookie)], Json(session)).into_response())
+    } else {
+        Err(Error::Unauthorized("unauthorized".into()))
+    }
 }
 
 async fn check_csrf(method: &Method, headers: &HeaderMap) -> Result<(), Error> {


### PR DESCRIPTION
The dashboard can now be dynamically available, or not.

Even with the `dashboard` feature endabled, you can skip setting `HQL_PASSWORD_DASHBOARD`. If unset, all dashboard routes will not be available. This makes it possible to just enable it when you need it and leave it unavailable for reduced attack surface otherwise.

An additional very simple rate-limiter has been added for the dashboard login and only a single password hash at a time is allocked now, guarded by a `Mutex`. You will never need concurrent logins to the dashboard and at the same time, this effectively prevents brute-force and DoS.