### PR TITLE
increase shutdown timeout

### DIFF
--- a/hiqlite/src/client/mgmt.rs
+++ b/hiqlite/src/client/mgmt.rs
@@ -210,7 +210,7 @@ impl Client {
         // This also helps to make re-joins after a restart smoother.
         // TODO for some very weird reason, the process sometimes gets stuck during
         // this sleep await when testing
-        time::sleep(Duration::from_secs(5)).await;
+        time::sleep(Duration::from_secs(10)).await;
 
         info!("Shutdown complete");
         Ok(())


### PR DESCRIPTION
I did some tests with a shorter shutdown wait of `5` seconds for a while and this can cause some disruption during K8s rolling releases. Until I found a nicer solution, the wait will be increased to 10 seconds, which seemed fine in older tests.

I am working on a more robust solution already, but it takes time and a lot of testing in real-world scenarios instead of integration tests.