### PR TITLE
feat: `sync_immediate` feature

### DIFF
--- a/config
+++ b/config
@@ -36,6 +36,25 @@ HQL_NODES="
 # default: false
 HQL_LOG_STATEMENTS=true
 
+# Enables immediate flush + sync to disk after each Log Store Batch.
+# The situations where you would need this are very rare, and you
+# should use it with care.
+#
+# The default is `false`, and a flush + sync will be done in 200ms
+# intervals. Even if the application should crash, the OS will take
+# care of flushing left-over buffers to disk and no data will get
+# lost. Only if something worse happens, you might lose the last
+# 200ms of commits.
+#
+# The only situation where you might want to enable this option is
+# when you are on a host that might lose power out of nowhere, and
+# it has no backup battery, or when your OS / disk itself is unstable.
+#
+# `sync_immediate` will greatly reduce the write throughput and put
+# a lot more pressure on the disk. If you have lots of writes, it
+# can pretty quickly kill your SSD for instance.
+#HQL_SYNC_IMMEDIATE=false
+
 # Sets the limit when the Raft will trigger the creation of a new
 # state machine snapshot and purge all logs that are included in
 # the snapshot.

--- a/hiqlite/src/store/mod.rs
+++ b/hiqlite/src/store/mod.rs
@@ -39,7 +39,9 @@ pub(crate) async fn start_raft_db(
     node_config: NodeConfig,
     raft_config: Arc<RaftConfig>,
 ) -> Result<StateRaftDB, Error> {
-    let log_store = logs::rocksdb::LogStoreRocksdb::new(&node_config.data_dir).await;
+    let log_store =
+        logs::rocksdb::LogStoreRocksdb::new(&node_config.data_dir, node_config.sync_immediate)
+            .await;
     let state_machine_store = StateMachineSqlite::new(
         &node_config.data_dir,
         &node_config.filename_db,


### PR DESCRIPTION
This will make it possible to immediately flush + sync all writes to disk after each single log store batch.
The situations where you might need this are rare, but they come up sometimes.