### PR TITLE
Revert shutdown delay changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,5 @@
 # Changelog
 
-## v0.3.3
-
-Further improvements for node shutdowns during rolling releases.
-
-The shutdown adds a delay on purpose for smoothing out Kubernetes rolling releases and
-make the whole process more graceful, because a whole new leader election might be necessary.
-The delay will be the `max(1500, sqlite.election_timeout_max, cache.election_timeout_max) * 3`
-in ms, and it will be added before shutting down the Raft layer and afterward as well.
-
-In future versions, there will be the possibility to trigger a graceful leader election
-upfront, but this has not been stabilized in this version.
-
 ## v0.3.2
 
 This version will make Raft cluster formation and re-joins of nodes after restarts more robust. Additional checks and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.3.3
+
+Further improvements for node shutdowns during rolling releases.
+
+The shutdown adds a delay on purpose for smoothing out Kubernetes rolling releases and
+make the whole process more graceful, because a whole new leader election might be necessary.
+The delay will be the `max(1500, sqlite.election_timeout_max, cache.election_timeout_max) * 3`
+in ms, and it will be added before shutting down the Raft layer and afterward as well.
+
+In future versions, there will be the possibility to trigger a graceful leader election
+upfront, but this has not been stabilized in this version.
+
 ## v0.3.2
 
 This version will make Raft cluster formation and re-joins of nodes after restarts more robust. Additional checks and

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["hiqlite"]
 exclude = ["examples"]
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Sebastian Dobe <sebastiandobe@mailbox.org"]

--- a/README.md
+++ b/README.md
@@ -504,7 +504,7 @@ spec:
     spec:
       containers:
         - name: hiqlite
-          image: ghcr.io/sebadob/hiqlite:0.3.2
+          image: ghcr.io/sebadob/hiqlite:0.3.3
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false
@@ -639,7 +639,7 @@ spec:
     spec:
       containers:
         - name: hiqlite-proxy
-          image: ghcr.io/sebadob/hiqlite:0.3.2
+          image: ghcr.io/sebadob/hiqlite:0.3.3
           command: [ "/app/hiqlite", "proxy" ]
           imagePullPolicy: Always
           securityContext:

--- a/examples/bench/Cargo.lock
+++ b/examples/bench/Cargo.lock
@@ -1240,7 +1240,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hiqlite"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "axum",
  "axum-server",

--- a/examples/cache-only/Cargo.lock
+++ b/examples/cache-only/Cargo.lock
@@ -876,7 +876,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hiqlite"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "axum",
  "axum-server",

--- a/examples/sqlite-only/Cargo.lock
+++ b/examples/sqlite-only/Cargo.lock
@@ -1179,7 +1179,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hiqlite"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "axum",
  "axum-server",

--- a/examples/walkthrough/Cargo.lock
+++ b/examples/walkthrough/Cargo.lock
@@ -1224,7 +1224,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hiqlite"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "axum",
  "axum-server",

--- a/hiqlite/Cargo.toml
+++ b/hiqlite/Cargo.toml
@@ -136,4 +136,5 @@ tower-service.workspace = true
 [dev-dependencies]
 console-subscriber = "0.4.1"
 tokio = { workspace = true, features = ["full", "test-util", "tracing"] }
+tokio-test = "0.4.4"
 tracing-subscriber.workspace = true

--- a/hiqlite/README.md
+++ b/hiqlite/README.md
@@ -504,7 +504,7 @@ spec:
     spec:
       containers:
         - name: hiqlite
-          image: ghcr.io/sebadob/hiqlite:0.3.2
+          image: ghcr.io/sebadob/hiqlite:0.3.3
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false
@@ -639,7 +639,7 @@ spec:
     spec:
       containers:
         - name: hiqlite-proxy
-          image: ghcr.io/sebadob/hiqlite:0.3.2
+          image: ghcr.io/sebadob/hiqlite:0.3.3
           command: [ "/app/hiqlite", "proxy" ]
           imagePullPolicy: Always
           securityContext:

--- a/hiqlite/src/client/mgmt.rs
+++ b/hiqlite/src/client/mgmt.rs
@@ -165,10 +165,8 @@ impl Client {
     /// Perform a graceful shutdown for this Raft node.
     /// Works on local clients only and can't shut down remote nodes.
     ///
-    /// The shutdown adds a delay on purpose for smoothing out Kubernetes rolling releases and
+    /// The shutdown adds a 10 delay on purpose for smoothing out Kubernetes rolling releases and
     /// make the whole process more graceful, because a whole new leader election might be necessary.
-    /// The delay will be the `max(1500, sqlite.election_timeout_max, cache.election_timeout_max) * 3`
-    /// in ms, and it will be added before shutting down the Raft layer and afterward as well.
     ///
     /// In future versions, there will be the possibility to trigger a graceful leader election
     /// upfront, but this has not been stabilized in this version.

--- a/hiqlite/src/client/mgmt.rs
+++ b/hiqlite/src/client/mgmt.rs
@@ -168,7 +168,7 @@ impl Client {
     /// The shutdown adds a delay on purpose for smoothing out Kubernetes rolling releases and
     /// make the whole process more graceful, because a whole new leader election might be necessary.
     /// The delay will be the `max(1500, sqlite.election_timeout_max, cache.election_timeout_max) * 3`
-    /// and it will be added before shutting down the Raft layer and afterward as well.
+    /// in ms, and it will be added before shutting down the Raft layer and afterward as well.
     ///
     /// In future versions, there will be the possibility to trigger a graceful leader election
     /// upfront, but this has not been stabilized in this version.

--- a/hiqlite/src/client/mgmt.rs
+++ b/hiqlite/src/client/mgmt.rs
@@ -296,7 +296,7 @@ impl Client {
         // don't make sense to me yet - needs further investigation until this sleep can be removed
         // safely.
         let delay = election_timeout_max * 5;
-        info!("Shutting down in {} ,s ...", delay);
+        info!("Shutting down in {} ms ...", delay);
         time::sleep(Duration::from_millis(delay)).await;
         // info!("Shutting down in 10 s ...");
         // time::sleep(Duration::from_secs(10)).await;

--- a/hiqlite/src/client/mgmt.rs
+++ b/hiqlite/src/client/mgmt.rs
@@ -196,52 +196,6 @@ impl Client {
         #[cfg(feature = "sqlite")] tx_client_db: &flume::Sender<ClientStreamReq>,
         tx_shutdown: &Option<watch::Sender<bool>>,
     ) -> Result<(), Error> {
-        // Before initiating the shutdown, we want to add a small delay for 2 reasons:
-        // - smooth out k8s rolling releases
-        // - with openraft 0.10, trigger a leader election before the delay to make it even smoother
-
-        let mut election_timeout_max = 1500;
-        #[cfg(feature = "cache")]
-        {
-            election_timeout_max = max(
-                election_timeout_max,
-                state.raft_cache.raft.config().heartbeat_interval,
-            );
-        }
-        #[cfg(feature = "sqlite")]
-        {
-            election_timeout_max = max(
-                election_timeout_max,
-                state.raft_db.raft.config().election_timeout_max,
-            );
-        }
-
-        // TODO as soon as openraft 0.10 is stable, trigger a graceful leader change here
-
-        /*
-        TODO this is very weird with openraft 0.9 -> something seems to be blocking internally
-        Only during integration tests, we can mess up the internal raft, if we sleep for
-        >= heartbeat_interval here. This has to do something with the way how tokio tests use
-        timing internally + the fact that something inside openraft 0.9 must be blocking, as I do
-        not have any other explanation for this. The upfront sleep is totally fine in any other
-        scenario. Anything else does not make sense, as just an async sleep should never mess up
-        logic in another place.
-        Currently, when we shut down a single client during tests and restart after deleting the
-        state machine and receive a snapshot and so on, the raft can get stuck. But again, only
-        inside #[tokio::test] when 3 nodes are started from the same test runtime
-         */
-
-        #[cfg(feature = "cache")]
-        {
-            info!("Shutting down raft cache layer");
-            match state.raft_cache.raft.shutdown().await {
-                Ok(_) => {}
-                Err(err) => {
-                    return Err(Error::Error(err.to_string().into()));
-                }
-            }
-        }
-
         #[cfg(feature = "sqlite")]
         {
             info!("Shutting down raft sqlite layer");
@@ -295,11 +249,8 @@ impl Client {
         // Note: The issue is "something blocking" in `openraft` but only in some conditions that
         // don't make sense to me yet - needs further investigation until this sleep can be removed
         // safely.
-        let delay = election_timeout_max * 5;
-        info!("Shutting down in {} ms ...", delay);
-        time::sleep(Duration::from_millis(delay)).await;
-        // info!("Shutting down in 10 s ...");
-        // time::sleep(Duration::from_secs(10)).await;
+        info!("Shutting down in 10 s ...");
+        time::sleep(Duration::from_secs(10)).await;
 
         info!("Shutdown complete");
         Ok(())

--- a/hiqlite/src/helpers.rs
+++ b/hiqlite/src/helpers.rs
@@ -29,10 +29,14 @@ pub async fn is_raft_initialized(
                 let metrics = state.raft_db.raft.server_metrics().borrow().clone();
 
                 #[cfg(debug_assertions)]
-                if metrics.current_leader.is_none() && metrics.vote.leader_id().node_id == state.id
+                if metrics.current_leader.is_none()
+                    && metrics.vote.leader_id().node_id == state.id
+                    && metrics.vote.committed
                 {
                     panic!(
-                        "current_leader.is_none() && metrics.vote.leader_id().node_id == state.id"
+                        "current_leader.is_none() && metrics.vote.leader_id().node_id == \
+                        state.id && metrics.vote.committed:\n{:?}",
+                        metrics
                     )
                 }
 

--- a/hiqlite/src/network/raft_client_split.rs
+++ b/hiqlite/src/network/raft_client_split.rs
@@ -229,6 +229,9 @@ impl NetworkStreaming {
                     Err(err) => {
                         error!("Socket connect error: {:?}", err);
 
+                        // TODO not sure which is better, sleep before drain or after -> more testing
+                        time::sleep(Duration::from_millis(heartbeat_interval * 3)).await;
+
                         // make sure messages don't pile up
                         rx.drain().for_each(|req| {
                             let ack = match req {
@@ -257,7 +260,7 @@ impl NetworkStreaming {
                         });
 
                         // if there is a network error, don't try too hard to connect
-                        time::sleep(Duration::from_millis(heartbeat_interval * 3)).await;
+                        // time::sleep(Duration::from_millis(heartbeat_interval * 3)).await;
                         continue;
                     }
                 }

--- a/hiqlite/src/server/config.rs
+++ b/hiqlite/src/server/config.rs
@@ -3,7 +3,7 @@ use crate::server::args::{ArgsConfig, ArgsGenerate};
 use crate::server::password;
 use crate::{Error, NodeConfig};
 use cryptr::{utils, EncKeys};
-use tokio::{fs, task};
+use tokio::fs;
 
 pub fn build_node_config(args: ArgsConfig) -> Result<NodeConfig, Error> {
     let config_path = if args.config_file == "$HOME/.hiqlite/config" {

--- a/hiqlite/src/store/logs/rocksdb.rs
+++ b/hiqlite/src/store/logs/rocksdb.rs
@@ -459,7 +459,8 @@ impl LogStoreRocksdb {
         opts.set_wal_size_limit_mb(wal_mb_logs);
         let logs = ColumnFamilyDescriptor::new("logs", opts.clone());
 
-        let db = DB::open_cf_descriptors(&opts, dir, vec![meta, logs]).unwrap();
+        let db = DB::open_cf_descriptors(&opts, dir, vec![meta, logs])
+            .expect("Cannot open rocksdb files on disk");
         let db = Arc::new(db);
 
         let tx_writer = LogStoreWriter::spawn(db.clone(), sync_immediate);

--- a/hiqlite/tests/cluster/self_heal.rs
+++ b/hiqlite/tests/cluster/self_heal.rs
@@ -3,7 +3,6 @@ use crate::{cache, check, log, Cache, TEST_DATA_DIR};
 use futures_util::future::join_all;
 use hiqlite::{start_node_with_cache, Client, Error};
 use std::time::Duration;
-use tokio::time::Instant;
 use tokio::{fs, time};
 
 pub async fn test_self_healing(

--- a/hiqlite/tests/cluster/start.rs
+++ b/hiqlite/tests/cluster/start.rs
@@ -17,6 +17,21 @@ pub async fn start_test_cluster() -> Result<(Client, Client, Client), Error> {
     Ok((client_1, client_2, client_3))
 }
 
+// pub async fn start_test_cluster() -> Result<(Client, Client, Client), Error> {
+//     let handle_client_1 =
+//         tokio_test::task::spawn(start_node_with_cache::<Cache>(build_config(1).await));
+//     let handle_client_2 =
+//         tokio_test::task::spawn(start_node_with_cache::<Cache>(build_config(2).await));
+//     let handle_client_3 =
+//         tokio_test::task::spawn(start_node_with_cache::<Cache>(build_config(3).await));
+//
+//     let client_1 = handle_client_1.await?;
+//     let client_2 = handle_client_2.await?;
+//     let client_3 = handle_client_3.await?;
+//
+//     Ok((client_1, client_2, client_3))
+// }
+
 pub fn nodes() -> Vec<Node> {
     vec![
         Node {

--- a/justfile
+++ b/justfile
@@ -166,13 +166,13 @@ build-release:
     set -euxo pipefail
     cargo build --release
 
-run ty="server":
+run ty="server" node_id="1":
     #!/usr/bin/env bash
     set -euxo pipefail
     clear
 
     if [[ {{ ty }} == "server" ]]; then
-      cargo run --features server -- serve
+      HQL_DATA_DIR=data/server_{{ node_id }} cargo run --features server --release -- serve -c config --node-id {{ node_id }}
     elif [[ {{ ty }} == "ui" ]]; then
       cd dashboard
       npm run dev -- --host=0.0.0.0


### PR DESCRIPTION
The shutdown delay changes looked fine in production and in all "real" scenarios so far, but they screwed up the tests.
I prefer everything to be stable in all cases, even if it means the shutdown delay would be a bit longer like before.