### PR TITLE
improved migration validation checks in sqlite writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## UNRELEASED
+
+Fixes an issue where the DB writer would panic because of a mismatch in DB Migrations validation. This could have
+happened if migrations are applied between applications starts. The `hiqlite::Client` in that case would only send the
+migrations over the network that have not been applied already and optimizes already existing ones away.
+However, the additional validation inside the DB writer (to make sure the client did not mess up) was too strict, and it
+would error.
+
 ## v0.3.2
 
 This version will make Raft cluster formation and re-joins of nodes after restarts more robust. Additional checks and

--- a/hiqlite/src/client/mgmt.rs
+++ b/hiqlite/src/client/mgmt.rs
@@ -17,7 +17,6 @@ use openraft::RaftMetrics;
 use openraft::ServerState;
 #[cfg(any(feature = "sqlite", feature = "cache"))]
 use std::clone::Clone;
-use std::cmp::max;
 
 impl Client {
     /// Get cluster metrics for the database Raft.
@@ -188,6 +187,7 @@ impl Client {
         }
     }
 
+    #[allow(unused_variables)]
     pub(crate) async fn shutdown_execute(
         state: &Arc<AppState>,
         #[cfg(feature = "cache")] tx_client_cache: &flume::Sender<ClientStreamReq>,

--- a/hiqlite/src/store/state_machine/sqlite/writer.rs
+++ b/hiqlite/src/store/state_machine/sqlite/writer.rs
@@ -748,7 +748,9 @@ fn last_applied_migration(
         .map(|r| r.expect("_migrations table corrupted"))
         .collect();
 
-    let mut last_applied = 0;
+    // We can safely set the last_applied here because we checked it would have thrown an error
+    // earlier otherwise already.
+    let mut last_applied = first_id - 1;
     for applied in already_applied {
         if last_applied + 1 != applied.id {
             panic!(

--- a/hiqlite/src/store/state_machine/sqlite/writer.rs
+++ b/hiqlite/src/store/state_machine/sqlite/writer.rs
@@ -750,6 +750,7 @@ fn last_applied_migration(
 
     // We can safely set the last_applied here because we checked it would have thrown an error
     // earlier otherwise already.
+    let applied_offset = (first_id - 1) as usize;
     let mut last_applied = first_id - 1;
     for applied in already_applied {
         if last_applied + 1 != applied.id {
@@ -761,7 +762,7 @@ fn last_applied_migration(
         }
         last_applied = applied.id;
 
-        match migrations.get(last_applied as usize - 1) {
+        match migrations.get(last_applied as usize - 1 - applied_offset) {
             None => panic!("Missing migration with id {}", last_applied),
             Some(migration) => {
                 if applied.id != migration.id {


### PR DESCRIPTION
Fixes an issue where the DB writer would panic because of a mismatch in DB Migrations validation.
This could have happened if migrations are applied between applications starts. The `hiqlite::Client` in that case would only send the migrations over the network that have not been applied already and optimizes already existing ones away.

However, the additional validation inside the DB writer (to make sure the client did not mess up) was too strict and it would error. This has been fixed.