### PR TITLE
fix secure Coockie add Path

### DIFF
--- a/hiqlite/src/dashboard/session.rs
+++ b/hiqlite/src/dashboard/session.rs
@@ -81,7 +81,7 @@ impl Session {
             )
         } else {
             format!(
-                "{}={}; Secure; HttpOnly; SameSite=Lax; Max-Age={}",
+                "{}={}; Secure; HttpOnly; SameSite=Lax; Max-Age={} Path=/",
                 COOKIE_NAME, b64, max_age
             )
         };


### PR DESCRIPTION
So, I have played around with the Dashboard, and was wondering why logging in was possible when I compiled it as standalone server but not when using rauthy.

I have to tell, that I am testing it under Windows.
hiqlite only needs the feature "asm" removed from sha2

 rauthy needed more some changes (locally I already merged the current v1.28, but not online):
https://github.com/cocoon/rauthy/commit/fb98277b0869f790b9298997f9b31003031f6612

So I am a bit in an unsupported area I would say ^^

In the end I found out it is because of the default config of hiqlite:
https://github.com/sebadob/hiqlite/blob/93080577900ac64b7c3ebaa73d2c2943cbcc9954/config#L197
`HQL_INSECURE_COOKIE=true`

and that is not set in rauthy.

But now I wanted to get it working and tried it with 
`HQL_INSECURE_COOKIE=true`

I used a new self signed cert, used a dns name (xyz.lab) not localhost using nginx as a reverse proxy to serve on port :443 and forward to :8200 and still FireFox and Chrome where not setting the __HOST-Cookie and rejected it, but not telling the exact reason what it did not like.

So I started to read about it and it seems that it is not so easy to really find the rules.

But later I found this:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie



> 
> Note: Some <cookie-name> have a specific semantic:
> 
> __Secure- prefix: Cookies with names starting with __Secure- (dash is part of the prefix) must be set with the secure flag from a secure page (HTTPS).
> 
> __Host- prefix: Cookies with names starting with __Host- are sent only to the host subdomain or domain that set them, and not to any other host. They must be set with the secure flag, must be from a secure page (HTTPS), must not have a domain specified, and the path must be /.
> 
> 

The important part is the very last one:
`and the path must be /`

Same here:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#cookie_prefixes

> Cookie prefixes
> 
> Cookie names prefixed with __Secure- or __Host- can be used only if they are set with the secure attribute from a secure (HTTPS) origin.
> 
> In addition, cookies with the __Host- prefix must have a path of / (meaning any path at the host) and must not have a Domain attribute.


So I added the fixed path here:
https://github.com/sebadob/hiqlite/blob/93080577900ac64b7c3ebaa73d2c2943cbcc9954/hiqlite/src/dashboard/session.rs#L84

like this:

`"{}={}; Secure; HttpOnly; SameSite=Lax; Max-Age={}; Path=/",`

And it was working!


And I also found this:
https://stackoverflow.com/a/73896447

that was leading to an interesting talk (video, just a part of it, some minutes)  about abusing cookies (especially the path, where longer path is set as first cookie):
https://youtu.be/njQcVWPB1is?t=2181

But that seems not to affect __HOST as it is expecting only / everything else is to be rejected.