### PR TITLE
fix: listen_notify_local feature to avoid pulling in eventsource_client

### DIFF
--- a/hiqlite/Cargo.toml
+++ b/hiqlite/Cargo.toml
@@ -48,10 +48,13 @@ full = [
     "webpki-roots",
 ]
 listen_notify = [
-    "dep:cryptr",
     "dep:eventsource-client",
+    "listen_notify_local"
+]
+listen_notify_local = [
+    "dep:cryptr",
     "dep:futures-util",
-    "cache",
+    "cache"
 ]
 s3 = ["dep:cryptr", "backup"]
 server = [

--- a/hiqlite/src/app_state.rs
+++ b/hiqlite/src/app_state.rs
@@ -13,7 +13,7 @@ use crate::client::stream::ClientStreamReq;
 use crate::dashboard::DashboardState;
 #[cfg(feature = "dlock")]
 use crate::store::state_machine::memory::dlock_handler::LockRequest;
-#[cfg(feature = "listen_notify")]
+#[cfg(feature = "listen_notify_local")]
 use crate::store::state_machine::memory::notify_handler::NotifyRequest;
 #[cfg(feature = "sqlite")]
 use crate::store::state_machine::sqlite::{
@@ -105,9 +105,9 @@ pub struct StateRaftCache {
     pub raft: openraft::Raft<TypeConfigKV>,
     pub lock: tokio::sync::Mutex<()>,
     pub tx_caches: Vec<flume::Sender<CacheRequestHandler>>,
-    #[cfg(feature = "listen_notify")]
+    #[cfg(feature = "listen_notify_local")]
     pub tx_notify: flume::Sender<NotifyRequest>,
-    #[cfg(feature = "listen_notify")]
+    #[cfg(feature = "listen_notify_local")]
     pub rx_notify: flume::Receiver<(i64, Vec<u8>)>,
     #[cfg(feature = "dlock")]
     pub tx_dlock: flume::Sender<LockRequest>,

--- a/hiqlite/src/client/cache.rs
+++ b/hiqlite/src/client/cache.rs
@@ -252,7 +252,7 @@ impl Client {
                 .expect("To always receive an answer from Client Stream Manager")?;
             match res {
                 ApiStreamResponsePayload::KV(res) => res,
-                #[cfg(any(feature = "sqlite", feature = "dlock", feature = "listen_notify"))]
+                #[cfg(any(feature = "sqlite", feature = "dlock", feature = "listen_notify_local"))]
                 _ => unreachable!(),
             }
         }

--- a/hiqlite/src/client/create.rs
+++ b/hiqlite/src/client/create.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use tokio::sync::{watch, RwLock};
 
 #[cfg(feature = "listen_notify")]
-use crate::client::listen_notify::RemoteListener;
+use crate::client::listen_notify::remote::RemoteListener;
 
 #[cfg(feature = "sqlite")]
 use crate::client::stream::ClientStreamReq;
@@ -50,9 +50,9 @@ impl Client {
             api_secret: None,
             request_id: AtomicUsize::new(0),
             tx_shutdown: Some(tx_shutdown),
-            #[cfg(feature = "listen_notify")]
+            #[cfg(feature = "listen_notify_local")]
             app_start: chrono::Utc::now().timestamp_micros(),
-            #[cfg(feature = "listen_notify")]
+            #[cfg(feature = "listen_notify_local")]
             rx_notify: None,
         };
 
@@ -132,6 +132,9 @@ impl Client {
             api_secret.clone(),
         ));
 
+        #[cfg(not(feature = "listen_notify"))]
+        let rx_notify = None;
+
         let api_secret_bytes = api_secret.as_bytes().to_vec();
 
         let db_client = DbClient {
@@ -156,9 +159,9 @@ impl Client {
             api_secret: Some(api_secret),
             request_id: AtomicUsize::new(0),
             tx_shutdown: None,
-            #[cfg(feature = "listen_notify")]
+            #[cfg(feature = "listen_notify_local")]
             app_start: chrono::Utc::now().timestamp_micros(),
-            #[cfg(feature = "listen_notify")]
+            #[cfg(feature = "listen_notify_local")]
             rx_notify,
         };
 

--- a/hiqlite/src/client/mod.rs
+++ b/hiqlite/src/client/mod.rs
@@ -17,7 +17,7 @@ pub mod dlock;
 #[cfg(feature = "sqlite")]
 mod execute;
 mod helpers;
-#[cfg(feature = "listen_notify")]
+#[cfg(feature = "listen_notify_local")]
 mod listen_notify;
 mod mgmt;
 #[cfg(feature = "sqlite")]
@@ -56,8 +56,8 @@ pub(crate) struct DbClient {
     pub(crate) api_secret: Option<String>,
     pub(crate) request_id: AtomicUsize,
     pub(crate) tx_shutdown: Option<watch::Sender<bool>>,
-    #[cfg(feature = "listen_notify")]
+    #[cfg(feature = "listen_notify_local")]
     pub(crate) app_start: i64,
-    #[cfg(feature = "listen_notify")]
+    #[cfg(feature = "listen_notify_local")]
     pub(crate) rx_notify: Option<flume::Receiver<(i64, Vec<u8>)>>,
 }

--- a/hiqlite/src/client/stream.rs
+++ b/hiqlite/src/client/stream.rs
@@ -59,7 +59,7 @@ pub(crate) enum ClientStreamReq {
     #[cfg(feature = "dlock")]
     LockAwait(ClientKVPayload),
 
-    #[cfg(feature = "listen_notify")]
+    #[cfg(feature = "listen_notify_local")]
     Notify(ClientKVPayload),
 
     Shutdown,
@@ -423,7 +423,7 @@ async fn client_stream(
                     ))
                 }
 
-                #[cfg(feature = "listen_notify")]
+                #[cfg(feature = "listen_notify_local")]
                 ClientStreamReq::Notify(ClientKVPayload {
                     request_id,
                     cache_req,
@@ -561,7 +561,7 @@ async fn client_stream(
                         "we should never receive ClientStreamReq::LockAwait from WS reader"
                     )
                 }
-                #[cfg(feature = "listen_notify")]
+                #[cfg(feature = "listen_notify_local")]
                 ClientStreamReq::Notify(_) => {
                     unreachable!("we should never receive ClientStreamReq::Notify from WS reader")
                 }

--- a/hiqlite/src/network/api.rs
+++ b/hiqlite/src/network/api.rs
@@ -311,7 +311,7 @@ pub(crate) enum ApiStreamRequestPayload {
     KVGet(CacheRequest),
     #[cfg(feature = "dlock")]
     LockAwait(CacheRequest),
-    #[cfg(feature = "listen_notify")]
+    #[cfg(feature = "listen_notify_local")]
     Notify(CacheRequest),
 }
 
@@ -347,7 +347,7 @@ pub(crate) enum ApiStreamResponsePayload {
     #[cfg(feature = "dlock")]
     Lock(LockState),
 
-    #[cfg(feature = "listen_notify")]
+    #[cfg(feature = "listen_notify_local")]
     Notify(Result<(), Error>),
 }
 
@@ -749,7 +749,7 @@ async fn handle_socket_concurrent(
                     }
                 }
 
-                #[cfg(feature = "listen_notify")]
+                #[cfg(feature = "listen_notify_local")]
                 ApiStreamRequestPayload::Notify(cache_req) => {
                     let (ts, data) = match cache_req {
                         CacheRequest::Notify((ts, data)) => (ts, data),

--- a/hiqlite/src/store/mod.rs
+++ b/hiqlite/src/store/mod.rs
@@ -125,9 +125,9 @@ where
     };
 
     let tx_caches = state_machine_store.tx_caches.clone();
-    #[cfg(feature = "listen_notify")]
+    #[cfg(feature = "listen_notify_local")]
     let tx_notify = state_machine_store.tx_notify.clone();
-    #[cfg(feature = "listen_notify")]
+    #[cfg(feature = "listen_notify_local")]
     let rx_notify = state_machine_store.rx_notify.clone();
 
     #[cfg(feature = "dlock")]
@@ -163,9 +163,9 @@ where
             raft,
             lock: Default::default(),
             tx_caches,
-            #[cfg(feature = "listen_notify")]
+            #[cfg(feature = "listen_notify_local")]
             tx_notify,
-            #[cfg(feature = "listen_notify")]
+            #[cfg(feature = "listen_notify_local")]
             rx_notify,
             #[cfg(feature = "dlock")]
             tx_dlock,

--- a/hiqlite/src/store/state_machine/memory/mod.rs
+++ b/hiqlite/src/store/state_machine/memory/mod.rs
@@ -9,7 +9,7 @@ pub mod state_machine;
 #[cfg(feature = "dlock")]
 pub mod dlock_handler;
 
-#[cfg(feature = "listen_notify")]
+#[cfg(feature = "listen_notify_local")]
 pub mod notify_handler;
 
 openraft::declare_raft_types!(


### PR DESCRIPTION
Hi, I'm evaluating this project and from the moment I found this on github I thought the idea behind it is quite awesome.

I'm only using the embedded mode, and enabling the `listen_notify` feature pulls in a problematic dependency: `eventsource_client`. It uses outdated versions of the hyper stack and I want to avoid the resulting bloat. This dependency is only used for the remote feature. Ideally, I think remote should be opt-in (perhaps even a separate crate?) because I think the value of this project is the embedded DB architecture.

However, this PR attempts to fix the dep issue now without breaking backwards-compatibility. It introduces a new feature `listen_notify_local`, which is the `listen_notify` feature just without the remote support. Let's see if it passes CI and if the general direction is agreeable.