### PR TITLE
emit a warning into the console if `LOG_STATEMENTS` is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.5.0
 
 - All internal dependencies have been bumped to the latest stable version.
-- If you don't need the `listen_notify` feature for remote clusters, you can now choose to only used
+- If you don't need the `listen_notify` feature for remote clusters, you can now choose to only use
   `listen_notify_local` instead, which will pull in less dependencies.
 - The `asm` feature has been removed from `sha2` to make it compile on windows.
 - The shutdown delay of 10 seconds is not being applied anymore if you only run a single instance, which usually is the

--- a/hiqlite/src/config.rs
+++ b/hiqlite/src/config.rs
@@ -3,7 +3,7 @@ use crate::{Error, Node, NodeId};
 use openraft::SnapshotPolicy;
 use std::borrow::Cow;
 use std::env;
-use tracing::debug;
+use tracing::{debug, warn};
 
 pub use openraft::Config as RaftConfig;
 
@@ -295,6 +295,18 @@ impl NodeConfig {
                     "password_dashboard should be at least 14 characters long".into(),
                 ));
             }
+        }
+
+        if self.log_statements {
+            warn!(
+                r#"
+
+!!! CAUTION !!!
+Statement logging is activated - this can leak sensitive information into your logs,
+as it will log query parameters as well. Be careful when using this in production and
+clean up logs after debugging!
+"#
+            )
         }
 
         Ok(())


### PR DESCRIPTION
`warn!` if `LOG_STATEMENTS=true`, because this can leak sensitive information into logs and should only be used carefully for debugging purposes.