### PR TITLE
feat: Param::StmtOutput

### DIFF
--- a/examples/sqlite-only/migrations/2_parentchild.sql
+++ b/examples/sqlite-only/migrations/2_parentchild.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS parent
+(
+    id          INTEGER PRIMARY KEY,
+    description TEXT
+);
+
+CREATE TABLE IF NOT EXISTS child
+(
+    id          INTEGER PRIMARY KEY,
+    parent_id   INTEGER NOT NULL REFERENCES parent(id) DEFERRABLE INITIALLY DEFERRED,
+    description TEXT
+);

--- a/hiqlite/src/lib.rs
+++ b/hiqlite/src/lib.rs
@@ -28,7 +28,7 @@ pub use client::dlock::Lock;
 #[cfg(feature = "sqlite")]
 pub use crate::query::rows::Row;
 #[cfg(feature = "sqlite")]
-pub use crate::store::state_machine::sqlite::{param::Param, state_machine::Params};
+pub use crate::store::state_machine::sqlite::{param::Param, state_machine::Params, transaction_variable::{StmtIndex, StmtColumn}};
 #[cfg(feature = "sqlite")]
 pub use migration::AppliedMigration;
 

--- a/hiqlite/src/store/state_machine/sqlite/mod.rs
+++ b/hiqlite/src/store/state_machine/sqlite/mod.rs
@@ -12,6 +12,9 @@ pub mod reader;
 pub mod snapshot_builder;
 pub mod state_machine;
 pub mod writer;
+pub mod transaction_variable;
+
+mod transaction_env;
 
 openraft::declare_raft_types!(
     pub TypeConfigSqlite:

--- a/hiqlite/src/store/state_machine/sqlite/transaction_env.rs
+++ b/hiqlite/src/store/state_machine/sqlite/transaction_env.rs
@@ -1,0 +1,85 @@
+use std::{borrow::Cow, collections::{hash_map::Entry, HashMap}};
+
+use rusqlite::{types::Value, Transaction};
+
+use crate::Error;
+
+/// A previously executed statement
+pub struct ExecutedStatement {
+    /// The executed SQL
+    pub sql: Cow<'static, str>,
+    /// The first returned row of the statement.
+    /// This will be empty if the statement returned no rows.
+    pub first_row: Vec<Value>,
+}
+
+impl ExecutedStatement {
+    fn by_index(statements: &[ExecutedStatement], index: usize) -> Result<&ExecutedStatement, Cow<'static, str>> {
+        Ok(statements.get(index).ok_or("statement index out of bounds")?)
+    }
+
+    fn get_first_row_value(&self, column_index: usize) -> Result<&Value, Cow<'static, str>> {
+        Ok(self.first_row.get(column_index).ok_or("column index out of bounds")?)
+    }
+}
+
+/// Data structure for supporting Param::StmtOutput
+pub struct TransactionEnv {
+    /// already executed statements
+    executed_stmts: Vec<ExecutedStatement>,
+
+    /// A cache of column indexes per statement
+    column_index_cache: HashMap<usize, HashMap<Cow<'static, str>, usize>>
+}
+
+impl TransactionEnv {
+    pub fn with_capacity(cap: usize) -> Self {
+        Self {
+            executed_stmts: Vec::with_capacity(cap),
+            column_index_cache: Default::default(),
+        }
+    }
+
+    pub fn push(&mut self, executed_stmt: ExecutedStatement) {
+        self.executed_stmts.push(executed_stmt);
+    }
+}
+
+/// A context for looking up Param variables
+pub struct TransactionParamContext<'a, 't> {
+    pub txn: &'a Transaction<'t>,
+    pub env: &'a mut TransactionEnv,
+}
+
+impl TransactionParamContext<'_, '_> {
+    pub fn lookup_statement_output_indexed(&mut self, statement_index: usize, column_index: usize) -> Result<Value, Cow<'static, str>> {
+        let executed_stmt = ExecutedStatement::by_index(&self.env.executed_stmts, statement_index)?;
+        Ok(executed_stmt.get_first_row_value(column_index)?.clone())
+    }
+
+    pub fn lookup_statement_output_named(&mut self, statement_index: usize, column_name: Cow<'static, str>) -> Result<Value, Cow<'static, str>> {
+        let executed_stmt = ExecutedStatement::by_index(&self.env.executed_stmts, statement_index)?;
+
+        let cache = self.env.column_index_cache.entry(statement_index).or_default();
+        let column_index = match cache.entry(column_name) {
+            Entry::Occupied(occpied) => *occpied.get(),
+            Entry::Vacant(vacant) => {
+                // Need to re-prepare the statement.
+                // Hopefully the statement will be cached.
+                // The statement has already been prepared (and error-checked) earlier, so should not fail.
+                let stmt = self.txn.prepare_cached(&executed_stmt.sql)
+                    .map_err(|_| "re-preparation")?;
+
+                let column_index = stmt.column_index(vacant.key())
+                    .map_err(|err| format!("{err:?}"))?;
+
+                // Cache the column index for later, in case the same value
+                // is used many times in the same transaction, which is not unlikely.
+                // This should avoid some statement re-preparation in larger transactions.
+                *vacant.insert(column_index)
+            },
+        };
+
+        Ok(executed_stmt.get_first_row_value(column_index)?.clone())
+    }
+}

--- a/hiqlite/src/store/state_machine/sqlite/transaction_variable.rs
+++ b/hiqlite/src/store/state_machine/sqlite/transaction_variable.rs
@@ -1,0 +1,17 @@
+/// A 0-based reference to a transaction statement
+#[derive(Clone, Copy)]
+pub struct StmtIndex(pub usize);
+
+impl StmtIndex {
+    /// Specify a column on the StmtIndex to produce a [StmtColumn].
+    pub fn column<C>(self, column: C) -> StmtColumn<C> {
+        StmtColumn { stmt_index: self, column }
+    }
+}
+
+/// A reference to a column produced by a statement in a transaction.
+#[derive(Clone, Copy)]
+pub struct StmtColumn<C> {
+    pub(crate) stmt_index: StmtIndex,
+    pub(crate) column: C,
+}


### PR DESCRIPTION
A proposed implementation of the idea in #118 . 

I tried to do it with as little overhead as possible if the feature is not in use: 

Each executed statement pushes an `ExecutedStatement` onto a new `Vec`. That data structure contains the input SQL (`Cow<'static, str>`). That string is now kept around longer than it was before. The data structure also contains a vector representing the returned row. If the statement returned nothing, that will be an empty `Vec`, which does not heap-allocate.

If the feature _is_ in use, you may look up a previous row value by column name. Getting the column index from the column name is done lazily by trying to re-use cached statements.

It's technically a breaking change because it adds a new variant to `Param` and the enum isn't `#[non_exhaustive]`.

The naming of various things is up for discussion.