### PR TITLE
improve shutdown stability

### DIFF
--- a/config
+++ b/config
@@ -1,6 +1,12 @@
 # env vars for parsing the NodeConfig
 # prefix for all of them: HIQ_
 
+# This is only a temp variable until everything is running very smooth and stable.
+# Can be adjusted to change the interval in seconds for the split brain checker.
+# This checker will be removed though as soon as everything is stable.
+# default: 300
+HQL_SPLIT_BRAIN_INTERVAL=10
+
 # Can be set to 'k8s' to try to split off the node id from the hostname
 # when Hiqlite is running as a StatefulSet inside Kubernetes.
 # Will be ignored if `HQL_NODE_ID_FROM=k8s`
@@ -80,6 +86,16 @@ HQL_LOG_STATEMENTS=true
 # snapshot creations / log purges.
 # default: 10000
 HQL_LOGS_UNTIL_SNAPSHOT=10000
+
+# The artificial shutdown delay to add in multi-node environments.
+# This value is being added before finally shutting down a node
+# to make sure rolling releases can be executed graceful with
+# proper leader switches. You may want to increase this value if
+# you are in an environment with huge in-memory caches and you
+# want to provide a bit more headroom for the snapshot replication
+# after restarts.
+# default: 5000
+HQL_SHUTDOWN_DELAY_MILLS=5000
 
 # If given, these keys / certificates will be used to establish
 # TLS connections between nodes.

--- a/examples/bench/Cargo.lock
+++ b/examples/bench/Cargo.lock
@@ -389,7 +389,7 @@ dependencies = [
  "num-traits",
  "rust-embed",
  "serde",
- "strum 0.26.3",
+ "strum",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1319,7 +1319,7 @@ dependencies = [
  "serde_json",
  "serde_rusqlite",
  "sha2",
- "strum 0.27.1",
+ "strum",
  "thiserror 2.0.3",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -2973,33 +2973,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 dependencies = [
- "strum_macros 0.27.1",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.89",
+ "strum_macros",
 ]
 
 [[package]]

--- a/hiqlite/src/app_state.rs
+++ b/hiqlite/src/app_state.rs
@@ -19,6 +19,7 @@ use crate::store::state_machine::memory::notify_handler::NotifyRequest;
 use crate::store::state_machine::sqlite::{
     state_machine::SqlitePool, writer::WriterRequest, TypeConfigSqlite,
 };
+use std::sync::atomic::AtomicBool;
 #[cfg(feature = "dashboard")]
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -65,6 +66,7 @@ pub(crate) struct AppState {
     pub client_request_id: AtomicUsize,
     #[cfg(feature = "dashboard")]
     pub tx_client_stream: flume::Sender<ClientStreamReq>,
+    pub shutdown_relay_millis: u32,
 }
 
 impl AppState {
@@ -98,6 +100,7 @@ pub struct StateRaftDB {
     pub sql_writer: flume::Sender<WriterRequest>,
     pub read_pool: SqlitePool,
     pub log_statements: bool,
+    pub is_raft_stopped: AtomicBool,
 }
 
 #[cfg(feature = "cache")]
@@ -111,4 +114,5 @@ pub struct StateRaftCache {
     pub rx_notify: flume::Receiver<(i64, Vec<u8>)>,
     #[cfg(feature = "dlock")]
     pub tx_dlock: flume::Sender<LockRequest>,
+    pub is_raft_stopped: AtomicBool,
 }

--- a/hiqlite/src/network/raft_server_split.rs
+++ b/hiqlite/src/network/raft_server_split.rs
@@ -2,11 +2,12 @@ use crate::network::handshake::HandshakeSecret;
 use crate::network::{serialize_network, AppStateExt, Error};
 use axum::response::IntoResponse;
 use fastwebsockets::{upgrade, FragmentCollectorRead, Frame, OpCode, Payload};
-use openraft::error::{InstallSnapshotError, RaftError};
+use openraft::error::{Fatal, InstallSnapshotError, RaftError};
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
+use std::sync::atomic::Ordering;
 use tokio::task;
-use tracing::{error, warn};
+use tracing::{debug, error, warn};
 
 #[cfg(feature = "cache")]
 use crate::store::state_machine::memory::TypeConfigKV;
@@ -90,15 +91,42 @@ impl From<Vec<u8>> for RaftStreamResponse {
     }
 }
 
-pub async fn stream(
+pub async fn stream_cache(
     state: AppStateExt,
     ws: upgrade::IncomingUpgrade,
 ) -> Result<impl IntoResponse, Error> {
-    let (response, socket) = ws.upgrade()?;
+    debug!("Incoming WebSocket stream for Cache");
 
+    #[cfg(feature = "cache")]
+    if state.raft_cache.is_raft_stopped.load(Ordering::Relaxed) {
+        return Err(Error::BadRequest("Raft has been stopped".into()));
+    }
+
+    let (response, socket) = ws.upgrade()?;
     tokio::task::spawn(async move {
         if let Err(err) = handle_socket(state, socket).await {
-            warn!("WebSocket stream closed: {}", err);
+            warn!("Cache WebSocket stream closed: {}", err);
+        }
+    });
+
+    Ok(response)
+}
+
+pub async fn stream_sqlite(
+    state: AppStateExt,
+    ws: upgrade::IncomingUpgrade,
+) -> Result<impl IntoResponse, Error> {
+    debug!("Incoming WebSocket stream for SQLite");
+
+    #[cfg(feature = "sqlite")]
+    if state.raft_db.is_raft_stopped.load(Ordering::Relaxed) {
+        return Err(Error::BadRequest("Raft has been stopped".into()));
+    }
+
+    let (response, socket) = ws.upgrade()?;
+    tokio::task::spawn(async move {
+        if let Err(err) = handle_socket(state, socket).await {
+            warn!("SQLite WebSocket stream closed: {}", err);
         }
     });
 
@@ -160,7 +188,6 @@ async fn handle_socket(
         let req = match frame.opcode {
             OpCode::Close => {
                 warn!("received Close frame in server stream");
-                // let _ = tx_write.send_async(WsWriteMsg::Break).await;
                 break;
             }
             OpCode::Binary => {
@@ -169,98 +196,85 @@ async fn handle_socket(
                     Ok(req) => req,
                     Err(err) => {
                         error!("Error deserializing RaftStreamRequest: {:?}", err);
-                        // let _ = tx_write.send_async(WsWriteMsg::Break).await;
                         break;
                     }
                 }
             }
             _ => {
                 warn!("Non binary payload received - exiting");
-                // let _ = tx_write.send_async(WsWriteMsg::Break).await;
                 break;
             }
         };
 
-        let tx_write = tx_write.clone();
-        let state = state.clone();
-        // TODO wrap this spawn in a timeout to prevent possible leaks?
-        task::spawn(async move {
-            let bytes = match req {
-                #[cfg(feature = "sqlite")]
-                RaftStreamRequest::AppendDB((request_id, req)) => {
-                    let res = state.raft_db.raft.append_entries(req).await;
-                    let resp = RaftStreamResponse {
-                        request_id,
-                        payload: RaftStreamResponsePayload::AppendDB(res),
-                    };
-                    serialize_network(&resp)
+        // Note: This was wrapped inside a `tokio::task` before just in case we would be able
+        // to achieve higher throughput. After in depth testing, at least with openraft 0.9, it
+        // has no benefit at all to do the extra work. Instead, it is actually a tiny performance
+        // penalty if we spawn a task each time - requests are coming in in-order anyway.
+        let (request_id, payload) = match req {
+            #[cfg(feature = "sqlite")]
+            RaftStreamRequest::AppendDB((request_id, req)) => {
+                let res = state.raft_db.raft.append_entries(req).await;
+                if let Err(RaftError::Fatal(Fatal::Stopped)) = &res {
+                    warn!("Raft DB stopped - exiting");
+                    state.raft_db.is_raft_stopped.store(true, Ordering::Relaxed);
+                    break;
                 }
-                #[cfg(feature = "sqlite")]
-                RaftStreamRequest::VoteDB((request_id, req)) => {
-                    let res = state.raft_db.raft.vote(req).await;
-                    let resp = RaftStreamResponse {
-                        request_id,
-                        payload: RaftStreamResponsePayload::VoteDB(res),
-                    };
-                    serialize_network(&resp)
-                }
-                #[cfg(feature = "sqlite")]
-                RaftStreamRequest::SnapshotDB((request_id, req)) => {
-                    let res = state.raft_db.raft.install_snapshot(req).await;
-                    let resp = RaftStreamResponse {
-                        request_id,
-                        payload: RaftStreamResponsePayload::SnapshotDB(res),
-                    };
-                    serialize_network(&resp)
-                }
-
-                #[cfg(feature = "cache")]
-                RaftStreamRequest::AppendCache((request_id, req)) => {
-                    let res = state.raft_cache.raft.append_entries(req).await;
-                    let resp = RaftStreamResponse {
-                        request_id,
-                        payload: RaftStreamResponsePayload::AppendCache(res),
-                    };
-                    serialize_network(&resp)
-                }
-                #[cfg(feature = "cache")]
-                RaftStreamRequest::VoteCache((request_id, req)) => {
-                    let res = state.raft_cache.raft.vote(req).await;
-                    let resp = RaftStreamResponse {
-                        request_id,
-                        payload: RaftStreamResponsePayload::VoteCache(res),
-                    };
-                    serialize_network(&resp)
-                }
-                #[cfg(feature = "cache")]
-                RaftStreamRequest::SnapshotCache((request_id, req)) => {
-                    let res = state.raft_cache.raft.install_snapshot(req).await;
-                    let resp = RaftStreamResponse {
-                        request_id,
-                        payload: RaftStreamResponsePayload::SnapshotCache(res),
-                    };
-                    serialize_network(&resp)
-                }
-            };
-
-            if let Err(err) = tx_write.send_async(WsWriteMsg::Payload(bytes)).await {
-                error!(
-                    "Error forwarding raft response to WebSocket writer: {}",
-                    err
-                );
+                (request_id, RaftStreamResponsePayload::AppendDB(res))
             }
-        });
-    }
+            #[cfg(feature = "sqlite")]
+            RaftStreamRequest::VoteDB((request_id, req)) => {
+                let res = state.raft_db.raft.vote(req).await;
+                (request_id, RaftStreamResponsePayload::VoteDB(res))
+            }
+            #[cfg(feature = "sqlite")]
+            RaftStreamRequest::SnapshotDB((request_id, req)) => {
+                let res = state.raft_db.raft.install_snapshot(req).await;
+                (request_id, RaftStreamResponsePayload::SnapshotDB(res))
+            }
 
-    // let res = select! {
-    //     res = handle_write => res,
-    //     res = handle_read => res,
-    // };
+            #[cfg(feature = "cache")]
+            RaftStreamRequest::AppendCache((request_id, req)) => {
+                let res = state.raft_cache.raft.append_entries(req).await;
+                if let Err(RaftError::Fatal(Fatal::Stopped)) = &res {
+                    warn!("Raft Cache stopped - exiting");
+                    state
+                        .raft_cache
+                        .is_raft_stopped
+                        .store(true, Ordering::Relaxed);
+                    break;
+                }
+                (request_id, RaftStreamResponsePayload::AppendCache(res))
+            }
+            #[cfg(feature = "cache")]
+            RaftStreamRequest::VoteCache((request_id, req)) => {
+                let res = state.raft_cache.raft.vote(req).await;
+                (request_id, RaftStreamResponsePayload::VoteCache(res))
+            }
+            #[cfg(feature = "cache")]
+            RaftStreamRequest::SnapshotCache((request_id, req)) => {
+                let res = state.raft_cache.raft.install_snapshot(req).await;
+                (request_id, RaftStreamResponsePayload::SnapshotCache(res))
+            }
+        };
+
+        if let Err(err) = tx_write
+            .send_async(WsWriteMsg::Payload(serialize_network(
+                &RaftStreamResponse {
+                    request_id,
+                    payload,
+                },
+            )))
+            .await
+        {
+            error!(
+                "Error forwarding raft response to WebSocket writer: {}",
+                err
+            );
+        }
+    }
 
     // try to close the writer if it should still be running
     let _ = tx_write.send_async(WsWriteMsg::Break).await;
-
-    // handle_read.abort();
 
     Ok(())
 }

--- a/hiqlite/src/start.rs
+++ b/hiqlite/src/start.rs
@@ -61,7 +61,7 @@ where
     let raft_db = store::start_raft_db(node_config.clone(), raft_config.clone()).await?;
     #[cfg(feature = "cache")]
     let (is_pristine_cache_node_1, raft_cache) =
-        store::start_raft_cache::<C>(node_config.clone(), raft_config).await?;
+        store::start_raft_cache::<C>(node_config.clone(), raft_config.clone()).await?;
 
     let (api_addr, rpc_addr) = {
         let node = node_config
@@ -106,6 +106,7 @@ where
         client_request_id: std::sync::atomic::AtomicUsize::new(0),
         #[cfg(feature = "dashboard")]
         tx_client_stream: tx_client_stream.clone(),
+        shutdown_relay_millis: node_config.shutdown_delay_millis,
     });
 
     #[cfg(any(feature = "sqlite", feature = "cache"))]
@@ -124,8 +125,8 @@ where
 
     let router_internal = Router::new()
         // .route("/stream", get(raft_server_split::stream))
-        .route("/stream/sqlite", get(raft_server_split::stream))
-        .route("/stream/cache", get(raft_server_split::stream))
+        .route("/stream/sqlite", get(raft_server_split::stream_sqlite))
+        .route("/stream/cache", get(raft_server_split::stream_cache))
         .route("/health", get(api::health))
         .route("/ping", get(api::ping))
         // .layer(compression_middleware.clone().into_inner())

--- a/hiqlite/src/store/mod.rs
+++ b/hiqlite/src/store/mod.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::cmp::PartialEq;
 use std::fmt::Debug;
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use strum::IntoEnumIterator;
 
@@ -102,6 +103,7 @@ pub(crate) async fn start_raft_db(
         sql_writer,
         read_pool,
         log_statements: node_config.log_statements,
+        is_raft_stopped: AtomicBool::new(false),
     })
 }
 
@@ -169,6 +171,7 @@ where
             rx_notify,
             #[cfg(feature = "dlock")]
             tx_dlock,
+            is_raft_stopped: AtomicBool::new(false),
         },
     ))
 }

--- a/justfile
+++ b/justfile
@@ -173,7 +173,7 @@ run ty="server" node_id="1":
     clear
 
     if [[ {{ ty }} == "server" ]]; then
-      HQL_DATA_DIR=data/server_{{ node_id }} cargo run --features server --release -- serve -c config --node-id {{ node_id }}
+      HQL_DATA_DIR=data/server_{{ node_id }} cargo run --features server -- serve -c config --node-id {{ node_id }}
     elif [[ {{ ty }} == "ui" ]]; then
       cd dashboard
       npm run dev -- --host=0.0.0.0


### PR DESCRIPTION
This PR takes care of additional shutdown stability improvements in situations where you are doing rolling releases.
A lot of additional things and checks are done and the stability has been improved a lot (so far). Especially in situations where you had an in-memory cache cluster which has no persistent state by definition. 

The adjustments needs more real world testing, but in my dev setup, I was unable to trigger the failing situation that sometimes occured before.