### PR TITLE
Feat: create `hiqlite-macros` + remove num traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["hiqlite"]
+members = ["hiqlite", "hiqlite-macros"]
 exclude = ["examples"]
 
 [workspace.package]
@@ -55,8 +55,6 @@ http-body-util = "0.1.2"
 hyper = { version = "1.4.1", features = ["client", "http2"] }
 hyper-util = { version = "0.1.6", features = ["client", "http2", "tokio"] }
 mime_guess = "2.0.5"
-num-traits = "0.2.19"
-num-derive = "0.4.2"
 openraft = { version = "0.9.18", features = ["serde", "storage-v2"] }
 reqwest = { version = "0.12", default-features = false, features = [
     "http2",

--- a/examples/bench/Cargo.lock
+++ b/examples/bench/Cargo.lock
@@ -386,7 +386,7 @@ dependencies = [
  "chrono",
  "clap",
  "hiqlite",
- "num-traits",
+ "hiqlite-macros",
  "rust-embed",
  "serde",
  "strum",
@@ -1306,8 +1306,6 @@ dependencies = [
  "hyper-util",
  "lazy_static",
  "lz4-sys",
- "num-derive",
- "num-traits",
  "openraft",
  "reqwest",
  "rocksdb",
@@ -1327,6 +1325,14 @@ dependencies = [
  "tower-service",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "hiqlite-macros"
+version = "0.6.0-20250410"
+dependencies = [
+ "hiqlite",
+ "rust-embed",
 ]
 
 [[package]]
@@ -2022,17 +2028,6 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.89",
-]
 
 [[package]]
 name = "num-traits"

--- a/examples/bench/Cargo.toml
+++ b/examples/bench/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2021"
 
 [dependencies]
 hiqlite = { path = "../../hiqlite", features = ["cache", "dlock", "listen_notify", "shutdown-handle"] }
+hiqlite-macros = { path = "../../hiqlite-macros" }
 
 # currently, we need this to embed migrations, as hiqlite does not re-export the full macro yet
 rust-embed = { version = "8.5.0", features = ["compression"] }
 
 # these 2 are needed for the cache index enum, as hiqlite does not re-export the full macros yet
 strum = { version = "0.27", features = ["derive"] }
-num-traits = "0.2.19"
 
 chrono = "0.4.38"
 clap = { version = "4.1.11", features = ["derive", "env"] }

--- a/examples/bench/src/bench.rs
+++ b/examples/bench/src/bench.rs
@@ -1,6 +1,7 @@
 use crate::{log, Cache, Options};
 use chrono::Utc;
-use hiqlite::{params, Client, Error, Param, Params, Row};
+use hiqlite::{Client, Error, Params, Row};
+use hiqlite_macros::params;
 use serde::{Deserialize, Serialize};
 use tokio::task;
 use tokio::time::Instant;

--- a/examples/bench/src/main.rs
+++ b/examples/bench/src/main.rs
@@ -1,5 +1,7 @@
 use clap::Parser;
+use hiqlite::cache_idx::CacheIndex;
 use hiqlite::{start_node_with_cache, Client, Error, Node, NodeConfig};
+use hiqlite_macros::embed::*;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display};
 use std::time::Duration;
@@ -9,7 +11,7 @@ use tracing_subscriber::EnvFilter;
 
 mod bench;
 
-#[derive(rust_embed::Embed)]
+#[derive(Embed)]
 #[folder = "migrations"]
 struct Migrations;
 
@@ -129,10 +131,20 @@ fn node_config(nodes: Vec<Node>, logs_until_snapshot: u64) -> NodeConfig {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, hiqlite::EnumIter, hiqlite::ToPrimitive)]
+#[derive(Debug, Serialize, Deserialize, strum::EnumIter)]
 enum Cache {
     One,
     Two,
+}
+
+// This tiny block of boilerplate is necessary to index concurrent caches properly.
+// The result must always return each elements position in the iterator and this simple typecasting
+// is the easiest way to do it. It is checked for correctness and compared against the iterator
+// during startup.
+impl CacheIndex for Cache {
+    fn to_usize(self) -> usize {
+        self as usize
+    }
 }
 
 #[tokio::main]

--- a/examples/cache-only/Cargo.lock
+++ b/examples/cache-only/Cargo.lock
@@ -425,7 +425,6 @@ name = "cache-only"
 version = "0.1.0"
 dependencies = [
  "hiqlite",
- "num-traits",
  "serde",
  "strum",
  "tokio",
@@ -917,8 +916,6 @@ dependencies = [
  "hyper-util",
  "lazy_static",
  "lz4-sys",
- "num-derive",
- "num-traits",
  "openraft",
  "reqwest",
  "rust-embed",
@@ -1431,17 +1428,6 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
-]
-
-[[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.89",
 ]
 
 [[package]]

--- a/examples/cache-only/Cargo.toml
+++ b/examples/cache-only/Cargo.toml
@@ -8,7 +8,6 @@ hiqlite = { path = "../../hiqlite", default-features = false, features = ["cache
 
 # these 2 are needed for the cache index enum, as hiqlite does not re-export the full macros yet
 strum = { version = "0.27", features = ["derive"] }
-num-traits = "0.2.19"
 
 serde = { version = "1.0.203", features = ["derive"] }
 tokio = { version = "1.43.1", features = ["fs", "rt-multi-thread"] }

--- a/examples/cache-only/src/main.rs
+++ b/examples/cache-only/src/main.rs
@@ -1,3 +1,4 @@
+use hiqlite::cache_idx::CacheIndex;
 use hiqlite::{Error, NodeConfig};
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
@@ -6,10 +7,20 @@ use tracing::info;
 use tracing_subscriber::EnvFilter;
 
 /// This enum is used as our cache identifier.
-#[derive(Debug, Serialize, Deserialize, hiqlite::EnumIter, hiqlite::ToPrimitive)]
+#[derive(Debug, Serialize, Deserialize, strum::EnumIter)]
 enum Cache {
     One,
     Two,
+}
+
+// This tiny block of boilerplate is necessary to index concurrent caches properly.
+// The result must always return each elements position in the iterator and this simple typecasting
+// is the easiest way to do it. It is checked for correctness and compared against the iterator
+// during startup.
+impl CacheIndex for Cache {
+    fn to_usize(self) -> usize {
+        self as usize
+    }
 }
 
 /// We will use this as our test value for the cache

--- a/examples/sqlite-only/Cargo.lock
+++ b/examples/sqlite-only/Cargo.lock
@@ -18,12 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "adler32"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
-
-[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,18 +36,6 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "version_check",
-]
-
-[[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
 ]
 
 [[package]]
@@ -79,12 +61,6 @@ checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
 ]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
 
 [[package]]
 name = "android-tzdata"
@@ -727,30 +703,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -814,12 +772,6 @@ dependencies = [
  "nix",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "dary_heap"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04d2cd9c18b9f454ed67da600630b021a8a80bf33f8c95896ab33aaf1c26b728"
 
 [[package]]
 name = "deadpool"
@@ -1168,17 +1120,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.8",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash 0.8.11",
- "allocator-api2",
+ "ahash",
 ]
 
 [[package]]
@@ -1242,8 +1184,6 @@ dependencies = [
  "hyper-util",
  "lazy_static",
  "lz4-sys",
- "num-derive",
- "num-traits",
  "openraft",
  "reqwest",
  "rocksdb",
@@ -1263,6 +1203,14 @@ dependencies = [
  "tower-service",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "hiqlite-macros"
+version = "0.6.0-20250410"
+dependencies = [
+ "hiqlite",
+ "rust-embed",
 ]
 
 [[package]]
@@ -1561,29 +1509,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "include-flate"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df49c16750695486c1f34de05da5b7438096156466e7f76c38fcdf285cf0113e"
-dependencies = [
- "include-flate-codegen",
- "lazy_static",
- "libflate",
-]
-
-[[package]]
-name = "include-flate-codegen"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c5b246c6261be723b85c61ecf87804e8ea4a35cb68be0ff282ed84b95ffe7d7"
-dependencies = [
- "libflate",
- "proc-macro2",
- "quote",
- "syn 2.0.89",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1666,30 +1591,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
-name = "libflate"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45d9dfdc14ea4ef0900c1cddbc8dcd553fbaacd8a4a282cf4018ae9dd04fb21e"
-dependencies = [
- "adler32",
- "core2",
- "crc32fast",
- "dary_heap",
- "libflate_lz77",
-]
-
-[[package]]
-name = "libflate_lz77"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e0d73b369f386f1c44abd9c570d5318f55ccde816ff4b562fa452e5182863d"
-dependencies = [
- "core2",
- "hashbrown 0.14.5",
- "rle-decode-fast",
-]
-
-[[package]]
 name = "libloading"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1710,8 +1611,6 @@ dependencies = [
  "cc",
  "libc",
  "libz-sys",
- "lz4-sys",
- "zstd-sys",
 ]
 
 [[package]]
@@ -1886,17 +1785,6 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.89",
-]
 
 [[package]]
 name = "num-traits"
@@ -2371,12 +2259,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rle-decode-fast"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
-
-[[package]]
 name = "rocksdb"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2408,7 +2290,6 @@ version = "8.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa66af4a4fdd5e7ebc276f115e895611a34739a9c1c01028383d612d550953c0"
 dependencies = [
- "include-flate",
  "rust-embed-impl",
  "rust-embed-utils",
  "walkdir",
@@ -2743,7 +2624,7 @@ name = "sqlite-only"
 version = "0.1.0"
 dependencies = [
  "hiqlite",
- "rust-embed",
+ "hiqlite-macros",
  "serde",
  "tokio",
  "tracing",
@@ -3704,14 +3585,4 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.89",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
-dependencies = [
- "cc",
- "pkg-config",
 ]

--- a/examples/sqlite-only/Cargo.toml
+++ b/examples/sqlite-only/Cargo.toml
@@ -5,9 +5,7 @@ edition = "2021"
 
 [dependencies]
 hiqlite = { path = "../../hiqlite", features = ["shutdown-handle"] }
-
-# currently, we need this to embed migrations, as hiqlite does not re-export the full macro yet
-rust-embed = { version = "8.5.0", features = ["compression"] }
+hiqlite-macros = { path = "../../hiqlite-macros" }
 
 serde = { version = "1.0.203", features = ["derive"] }
 tokio = { version = "1.43.1", features = ["fs", "rt-multi-thread"] }

--- a/examples/sqlite-only/src/main.rs
+++ b/examples/sqlite-only/src/main.rs
@@ -1,9 +1,11 @@
-use hiqlite::{params, Error, NodeConfig, Param, Row, StmtIndex};
+use hiqlite::{Error, NodeConfig, Row, StmtIndex};
+use hiqlite_macros::embed::*;
+use hiqlite_macros::params;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display};
 use tracing_subscriber::EnvFilter;
 
-#[derive(rust_embed::Embed)]
+#[derive(Embed)]
 #[folder = "migrations"]
 struct Migrations;
 
@@ -147,7 +149,10 @@ async fn main() -> Result<(), Error> {
             (insert_child, params!(StmtIndex(0).column(0), "child A.1")),
             (insert_child, params!(StmtIndex(0).column(0), "child A.2")),
             // We can also refer to a column by name. Now using "parent B":
-            (insert_child, params!(StmtIndex(1).column("id"), "child B.1")),
+            (
+                insert_child,
+                params!(StmtIndex(1).column("id"), "child B.1"),
+            ),
         ])
         .await;
 

--- a/examples/walkthrough/Cargo.lock
+++ b/examples/walkthrough/Cargo.lock
@@ -18,12 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "adler32"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
-
-[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,18 +36,6 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "version_check",
-]
-
-[[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
 ]
 
 [[package]]
@@ -79,12 +61,6 @@ checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
 ]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
 
 [[package]]
 name = "android-tzdata"
@@ -737,30 +713,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -824,12 +782,6 @@ dependencies = [
  "nix",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "dary_heap"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04d2cd9c18b9f454ed67da600630b021a8a80bf33f8c95896ab33aaf1c26b728"
 
 [[package]]
 name = "deadpool"
@@ -1214,17 +1166,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.8",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash 0.8.11",
- "allocator-api2",
+ "ahash",
 ]
 
 [[package]]
@@ -1290,8 +1232,6 @@ dependencies = [
  "hyper-util",
  "lazy_static",
  "lz4-sys",
- "num-derive",
- "num-traits",
  "openraft",
  "reqwest",
  "rocksdb",
@@ -1311,6 +1251,14 @@ dependencies = [
  "tower-service",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "hiqlite-macros"
+version = "0.6.0-20250410"
+dependencies = [
+ "hiqlite",
+ "rust-embed",
 ]
 
 [[package]]
@@ -1683,29 +1631,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "include-flate"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df49c16750695486c1f34de05da5b7438096156466e7f76c38fcdf285cf0113e"
-dependencies = [
- "include-flate-codegen",
- "lazy_static",
- "libflate",
-]
-
-[[package]]
-name = "include-flate-codegen"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c5b246c6261be723b85c61ecf87804e8ea4a35cb68be0ff282ed84b95ffe7d7"
-dependencies = [
- "libflate",
- "proc-macro2",
- "quote",
- "syn 2.0.89",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1786,30 +1711,6 @@ name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
-
-[[package]]
-name = "libflate"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45d9dfdc14ea4ef0900c1cddbc8dcd553fbaacd8a4a282cf4018ae9dd04fb21e"
-dependencies = [
- "adler32",
- "core2",
- "crc32fast",
- "dary_heap",
- "libflate_lz77",
-]
-
-[[package]]
-name = "libflate_lz77"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e0d73b369f386f1c44abd9c570d5318f55ccde816ff4b562fa452e5182863d"
-dependencies = [
- "core2",
- "hashbrown 0.14.5",
- "rle-decode-fast",
-]
 
 [[package]]
 name = "libloading"
@@ -2006,17 +1907,6 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.89",
-]
 
 [[package]]
 name = "num-traits"
@@ -2491,12 +2381,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rle-decode-fast"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
-
-[[package]]
 name = "rocksdb"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2528,7 +2412,6 @@ version = "8.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa66af4a4fdd5e7ebc276f115e895611a34739a9c1c01028383d612d550953c0"
 dependencies = [
- "include-flate",
  "rust-embed-impl",
  "rust-embed-utils",
  "walkdir",
@@ -3485,8 +3368,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "hiqlite",
- "num-traits",
- "rust-embed",
+ "hiqlite-macros",
  "serde",
  "strum",
  "tokio",

--- a/examples/walkthrough/Cargo.toml
+++ b/examples/walkthrough/Cargo.toml
@@ -5,16 +5,14 @@ edition = "2021"
 
 [dependencies]
 hiqlite = { path = "../../hiqlite", features = ["cache", "dlock", "listen_notify", "shutdown-handle"] }
-
-# currently, we need this to embed migrations, as hiqlite does not re-export the full macro yet
-rust-embed = { version = "8.5.0", features = ["compression"] }
+hiqlite-macros = { path = "../../hiqlite-macros" }
 
 # these 2 are needed for the cache index enum, as hiqlite does not re-export the full macros yet
-strum = { version = "0.27", features = ["derive"] }
-num-traits = "0.2.19"
+strum = "0.27.1"
 
 clap = { version = "4.1.11", features = ["derive", "env"] }
 serde = { version = "1.0.203", features = ["derive"] }
 tokio = { version = "1.43.1", features = ["fs", "rt-multi-thread"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.0", features = ["env-filter"] }
+#

--- a/hiqlite-macros/Cargo.toml
+++ b/hiqlite-macros/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "hiqlite-macros"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+rust-version = "1.82.0"
+categories = ["database", "caching"]
+keywords = ["database", "sql", "sqlite", "raft", "cache"]
+description = "Macros for Hiqlite"
+repository = "https://github.com/sebadob/hiqlite"
+
+[lib]
+doctest = false
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+hiqlite = { version = "0.6.0-20250410", path = "../hiqlite" }
+
+rust-embed.workspace = true

--- a/hiqlite-macros/src/lib.rs
+++ b/hiqlite-macros/src/lib.rs
@@ -1,0 +1,19 @@
+pub mod embed {
+    pub use rust_embed::{self, *};
+}
+
+/// Helper macro to created Owned Params which can be serialized and sent
+/// over the Raft network between nodes.
+#[macro_export]
+macro_rules! params {
+    ( $( $param:expr ),* ) => {
+        {
+            #[allow(unused_mut)]
+            let mut params = Vec::with_capacity(2);
+            $(
+                params.push(hiqlite::Param::from($param));
+            )*
+            params
+        }
+    };
+}

--- a/hiqlite/Cargo.toml
+++ b/hiqlite/Cargo.toml
@@ -103,8 +103,6 @@ http-body-util.workspace = true
 hyper.workspace = true
 hyper-util.workspace = true
 mime_guess = { workspace = true, optional = true }
-num-traits.workspace = true
-num-derive.workspace = true
 openraft.workspace = true
 # TODO not competitive for logs right now, maybe get rid of it in the future
 #redb.workspace = true

--- a/hiqlite/src/cache_idx.rs
+++ b/hiqlite/src/cache_idx.rs
@@ -1,0 +1,3 @@
+pub trait CacheIndex {
+    fn to_usize(self) -> usize;
+}

--- a/hiqlite/src/client/migrate.rs
+++ b/hiqlite/src/client/migrate.rs
@@ -2,7 +2,7 @@ use crate::client::stream::{ClientMigratePayload, ClientStreamReq};
 use crate::migration::{Migration, Migrations};
 use crate::network::api::ApiStreamResponsePayload;
 use crate::store::state_machine::sqlite::state_machine::QueryWrite;
-use crate::{params, AppliedMigration, Client, Error, Response};
+use crate::{AppliedMigration, Client, Error, Params, Response};
 use rust_embed::RustEmbed;
 use tokio::sync::oneshot;
 use tracing::{info, warn};
@@ -25,7 +25,7 @@ impl Client {
     #[cold]
     pub async fn migrate<T: RustEmbed>(&self) -> Result<(), Error> {
         let applied: Vec<AppliedMigration> = self
-            .query_map("SELECT * FROM _migrations ORDER BY id ASC", params!())
+            .query_map("SELECT * FROM _migrations ORDER BY id ASC", Params::new())
             .await
             .unwrap_or_default();
         let mut migrations = Migrations::build::<T>();

--- a/hiqlite/src/dashboard/query.rs
+++ b/hiqlite/src/dashboard/query.rs
@@ -2,7 +2,7 @@ use crate::network::api::ApiStreamResponsePayload;
 use crate::network::AppStateExt;
 use crate::query::rows::{ColumnOwned, RowOwned, ValueOwned};
 use crate::store::state_machine::sqlite::state_machine::{Query, QueryWrite};
-use crate::{params, Error};
+use crate::{Error, Params};
 use tokio::sync::oneshot;
 use tokio::task;
 use tracing::info;
@@ -46,7 +46,7 @@ pub(crate) async fn dashboard_query_dynamic(
     } else {
         let sql = Query {
             sql: sql.into(),
-            params: params!(),
+            params: Params::new(),
         };
 
         // TODO check for `RETURNING` to execute `query` instead

--- a/hiqlite/src/dashboard/table.rs
+++ b/hiqlite/src/dashboard/table.rs
@@ -1,7 +1,7 @@
 use crate::dashboard::handlers::TableFilterRequest;
 use crate::network::AppStateExt;
 use crate::query::query_map;
-use crate::{params, Error, Param, Row};
+use crate::{Error, Param, Params, Row};
 use serde::Serialize;
 
 #[derive(Debug, Serialize)]
@@ -58,7 +58,7 @@ impl Table {
         let res: Vec<Self> = query_map(
             state,
             "SELECT type,name,tbl_name,sql FROM sqlite_master",
-            params!(),
+            Params::new(),
         )
         .await?;
 
@@ -72,7 +72,7 @@ impl Table {
         let res: Vec<Self> = query_map(
             state,
             "SELECT type,name,tbl_name,sql FROM sqlite_master WHERE type = $1",
-            params!(filter.as_str()),
+            vec![Param::Text(filter.as_str().to_string())],
         )
         .await?;
 

--- a/hiqlite/src/server/cache.rs
+++ b/hiqlite/src/server/cache.rs
@@ -1,9 +1,11 @@
-use num_derive::ToPrimitive;
+use crate::cache_idx::CacheIndex;
 use serde::{Deserialize, Serialize};
 use strum::EnumIter;
 
-#[derive(Debug, Serialize, Deserialize, EnumIter, ToPrimitive)]
+#[derive(Debug, Serialize, Deserialize, EnumIter)]
 pub enum Cache {
     Intern,
     Extern,
 }
+
+impl CacheIndex for Cache {}

--- a/hiqlite/src/start.rs
+++ b/hiqlite/src/start.rs
@@ -27,7 +27,7 @@ where
         + Serialize
         + for<'a> Deserialize<'a>
         + strum::IntoEnumIterator
-        + num_traits::ToPrimitive,
+        + crate::cache_idx::CacheIndex,
 {
     node_config.is_valid()?;
 

--- a/hiqlite/src/store/mod.rs
+++ b/hiqlite/src/store/mod.rs
@@ -4,7 +4,6 @@ use crate::app_state::{AppState, RaftType};
 use crate::init::IsPristineNode1;
 use crate::network::NetworkStreaming;
 use crate::{init, Error, NodeConfig, NodeId, RaftConfig};
-use num_traits::ToPrimitive;
 use openraft::storage::RaftLogStorage;
 use openraft::{Raft, StorageError};
 use serde::{Deserialize, Serialize};
@@ -113,7 +112,11 @@ pub(crate) async fn start_raft_cache<C>(
     raft_config: Arc<RaftConfig>,
 ) -> Result<(IsPristineNode1, StateRaftCache), Error>
 where
-    C: Debug + Serialize + for<'a> Deserialize<'a> + IntoEnumIterator + ToPrimitive,
+    C: Debug
+        + Serialize
+        + for<'a> Deserialize<'a>
+        + IntoEnumIterator
+        + crate::cache_idx::CacheIndex,
 {
     let log_store = logs::memory::LogStoreMemory::new();
     let state_machine_store = Arc::new(StateMachineMemory::new::<C>().await?);

--- a/hiqlite/tests/cluster/backup.rs
+++ b/hiqlite/tests/cluster/backup.rs
@@ -1,5 +1,5 @@
-use crate::{log, TEST_DATA_DIR};
-use hiqlite::{params, Client, Error, Param};
+use crate::{log, params, TEST_DATA_DIR};
+use hiqlite::{Client, Error};
 use std::time::Duration;
 use tokio::{fs, time};
 

--- a/hiqlite/tests/cluster/backup_restore.rs
+++ b/hiqlite/tests/cluster/backup_restore.rs
@@ -1,8 +1,8 @@
 use crate::backup::BACKUP_PATH_FILE;
 use crate::execute_query::TestData;
 use crate::start::build_config;
-use crate::{backup, log, Cache};
-use hiqlite::{params, start_node_with_cache, Client, Error, Param};
+use crate::{backup, log, params, Cache};
+use hiqlite::{start_node_with_cache, Client, Error};
 use std::env;
 use tokio::task;
 

--- a/hiqlite/tests/cluster/batch.rs
+++ b/hiqlite/tests/cluster/batch.rs
@@ -1,7 +1,7 @@
 use crate::execute_query::TestData;
-use crate::log;
+use crate::{log, params};
 use chrono::Utc;
-use hiqlite::{params, Client, Error, Param};
+use hiqlite::{Client, Error};
 use std::time::Duration;
 use tokio::time;
 

--- a/hiqlite/tests/cluster/check.rs
+++ b/hiqlite/tests/cluster/check.rs
@@ -1,6 +1,6 @@
 use crate::execute_query::TestData;
-use crate::{debug, log};
-use hiqlite::{params, Client, Error, Param};
+use crate::{debug, log, params};
+use hiqlite::{Client, Error};
 
 use crate::cache::{KEY, KEY_2, VALUE, VALUE_2};
 use crate::Cache;

--- a/hiqlite/tests/cluster/execute_query.rs
+++ b/hiqlite/tests/cluster/execute_query.rs
@@ -1,6 +1,6 @@
-use crate::log;
+use crate::{log, params};
 use chrono::Utc;
-use hiqlite::{params, Client, Error, Param};
+use hiqlite::{Client, Error};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use tokio::time;

--- a/hiqlite/tests/cluster/main.rs
+++ b/hiqlite/tests/cluster/main.rs
@@ -1,5 +1,6 @@
 use crate::self_heal::test_self_healing;
 use futures_util::future::join_all;
+use hiqlite::cache_idx::CacheIndex;
 use hiqlite::Error;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display};
@@ -29,11 +30,31 @@ mod type_conversions;
 
 pub const TEST_DATA_DIR: &str = "tests/data_test";
 
-#[derive(Debug, Serialize, Deserialize, hiqlite::EnumIter, hiqlite::ToPrimitive)]
+#[macro_export]
+macro_rules! params {
+    ( $( $param:expr ),* ) => {
+        {
+            #[allow(unused_mut)]
+            let mut params = Vec::with_capacity(2);
+            $(
+                params.push(hiqlite::Param::from($param));
+            )*
+            params
+        }
+    };
+}
+
+#[derive(Debug, Serialize, Deserialize, strum::EnumIter)]
 enum Cache {
     One,
     Two,
     Three,
+}
+
+impl CacheIndex for Cache {
+    fn to_usize(self) -> usize {
+        self as usize
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/hiqlite/tests/cluster/migration.rs
+++ b/hiqlite/tests/cluster/migration.rs
@@ -1,6 +1,6 @@
 use crate::execute_query::TestData;
-use crate::{debug, log};
-use hiqlite::{params, AppliedMigration, Client, Error};
+use crate::{debug, log, params};
+use hiqlite::{AppliedMigration, Client, Error};
 use std::time::Duration;
 use tokio::time;
 

--- a/hiqlite/tests/cluster/remote_only.rs
+++ b/hiqlite/tests/cluster/remote_only.rs
@@ -1,8 +1,8 @@
 use crate::execute_query::TestData;
 use crate::start::SECRET_API;
-use crate::{check, log, start, Cache};
+use crate::{check, log, params, start, Cache};
 use chrono::Utc;
-use hiqlite::{params, Client, Error, Lock, Param};
+use hiqlite::{Client, Error, Lock};
 use std::time::Duration;
 use tokio::{task, time};
 

--- a/hiqlite/tests/cluster/transaction.rs
+++ b/hiqlite/tests/cluster/transaction.rs
@@ -1,7 +1,7 @@
 use crate::execute_query::TestData;
-use crate::log;
+use crate::{log, params};
 use chrono::Utc;
-use hiqlite::{params, Client, Error, Param};
+use hiqlite::{Client, Error};
 use std::time::Duration;
 use tokio::time;
 

--- a/hiqlite/tests/cluster/type_conversions.rs
+++ b/hiqlite/tests/cluster/type_conversions.rs
@@ -1,6 +1,6 @@
-use crate::debug;
+use crate::{debug, params};
 use chrono::{DateTime, FixedOffset, Local, NaiveDate, NaiveDateTime, NaiveTime, Utc};
-use hiqlite::{params, Client, Error, Param, Row};
+use hiqlite::{Client, Error, Row};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq)]


### PR DESCRIPTION
This PR creates the new `hiqlite-macros` crate. It only implements `params!()` for now, which has been moved from `hiqlite::params` into `hiqlite_macros::params`. This move got rid of the additional manual import of `hiqlite::Param` that was necessary with the macro before.

`hiqlite_macros` also made it possible to re-export `rust_embed` in a way, that you don't need to add it manually to your deps anymore. Instead, you can now do `use hiqlite_macros::embed::*;` and use the `Embed` derive on your Migrations directly.

This PR also dropped the `num-traits` and `num-derive` dependencies, which you don't need to add anymore as well. Instead, a new `trait CacheIndex`  has been defined. This does not have a macro yet, but the bopilerplate it only 3 lines and kind of looks like this:

```rust
impl CacheIndex for Cache {
    fn to_usize(self) -> usize {
        self as usize
    }
}
```

Having 3 lines of boilerplates compared to 2 additional full crate dependencies is a very good tradeoff. As soon as I have made myself familiar with writing proc macros, I will probably create a `derive` macro for this tiny block as well.

This means, the only left-over direct dependency you have to add when using the cache is `strum`. The plan for future updates is to get rid of this as well.