### PR TITLE
Feat: create `hiqlite-wal` for evtually drop `rocksdb` as logs store

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["hiqlite", "hiqlite-macros"]
+members = ["hiqlite", "hiqlite-macros", "hiqlite-wal"]
 exclude = ["examples"]
 
 [workspace.package]
@@ -34,6 +34,7 @@ chrono = { version = "0.4.38", default-features = false, features = [
     #"serde",
 ] }
 clap = { version = "4.1.11", features = ["derive", "env"] }
+crc = "3.3.0"
 cron = { version = "0.15" }
 cryptr = { version = "0.6", features = ["s3"] }
 ctrlc = { version = "3.4.4", features = ["termination"] }
@@ -54,6 +55,7 @@ hostname = "0.4.0"
 http-body-util = "0.1.2"
 hyper = { version = "1.4.1", features = ["client", "http2"] }
 hyper-util = { version = "0.1.6", features = ["client", "http2", "tokio"] }
+memmap2 = "0.9.5"
 mimalloc = "0.1.46"
 mime_guess = "2.0.5"
 openraft = { version = "0.9.18", features = ["serde", "storage-v2"] }

--- a/hiqlite-wal/.gitignore
+++ b/hiqlite-wal/.gitignore
@@ -1,0 +1,1 @@
+test_data

--- a/hiqlite-wal/Cargo.toml
+++ b/hiqlite-wal/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "hiqlite-wal"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+rust-version = "1.85.1"
+categories = ["database", "caching"]
+keywords = ["database", "raft", "cache", "wal"]
+description = "WAL file implementation for Hiqlite"
+repository = "https://github.com/sebadob/hiqlite"
+
+[lib]
+doctest = false
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+bincode.workspace = true
+byteorder.workspace = true
+crc.workspace = true
+flume.workspace = true
+memmap2.workspace = true
+openraft.workspace = true
+serde.workspace = true
+thiserror.workspace = true
+tokio.workspace = true

--- a/hiqlite-wal/src/error.rs
+++ b/hiqlite-wal/src/error.rs
@@ -1,0 +1,44 @@
+use std::borrow::Cow;
+use std::io;
+use std::num::ParseIntError;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("DecodeError: {0}")]
+    DecodeError(String),
+    #[error("EncodeError: {0}")]
+    EncodeError(String),
+    #[error("FileCorrupted: {0}")]
+    FileCorrupted(&'static str),
+    #[error("Integrity: {0}")]
+    Integrity(Cow<'static, str>),
+    #[error("InvalidPath: {0}")]
+    InvalidPath(&'static str),
+    #[error("InvalidFileName")]
+    InvalidFileName,
+    #[error("IOError: {0}")]
+    IOError(#[from] io::Error),
+    #[error("Locked: {0}")]
+    Locked(&'static str),
+    #[error("ParseError: {0}")]
+    ParseError(&'static str),
+}
+
+impl From<bincode::error::DecodeError> for Error {
+    fn from(err: bincode::error::DecodeError) -> Self {
+        Self::DecodeError(err.to_string())
+    }
+}
+
+impl From<bincode::error::EncodeError> for Error {
+    fn from(err: bincode::error::EncodeError) -> Self {
+        Self::EncodeError(err.to_string())
+    }
+}
+
+impl From<ParseIntError> for Error {
+    fn from(_: ParseIntError) -> Self {
+        Self::ParseError("Cannot parse value as integer")
+    }
+}

--- a/hiqlite-wal/src/lib.rs
+++ b/hiqlite-wal/src/lib.rs
@@ -1,0 +1,5 @@
+mod error;
+mod metadata;
+mod utils;
+mod wal;
+pub mod writer;

--- a/hiqlite-wal/src/utils.rs
+++ b/hiqlite-wal/src/utils.rs
@@ -1,0 +1,40 @@
+use crate::error::Error;
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use serde::{Deserialize, Serialize};
+
+pub const CHKSUM: crc::Crc<u32> = crc::Crc::<u32>::new(&crc::CRC_32_CKSUM);
+
+macro_rules! crc {
+    ($input:expr) => {{
+        crate::utils::CHKSUM.checksum($input).to_le_bytes()
+    }};
+}
+pub(crate) use crc;
+
+#[inline]
+pub fn id_to_bin(id: u64, buf: &mut Vec<u8>) -> Result<(), Error> {
+    buf.write_u64::<LittleEndian>(id)?;
+    Ok(())
+}
+
+#[inline]
+pub fn bin_to_id(buf: &[u8]) -> Result<u64, Error> {
+    Ok((&buf[0..8]).read_u64::<LittleEndian>()?)
+}
+
+#[inline(always)]
+pub fn serialize<T: Serialize>(value: &T) -> Result<Vec<u8>, Error> {
+    Ok(bincode::serde::encode_to_vec(
+        value,
+        bincode::config::standard(),
+    )?)
+}
+
+#[inline]
+pub fn deserialize<T>(bytes: &[u8]) -> Result<T, Error>
+where
+    T: for<'a> Deserialize<'a>,
+{
+    let (res, _) = bincode::serde::decode_from_slice::<T, _>(bytes, bincode::config::standard())?;
+    Ok(res)
+}

--- a/hiqlite-wal/src/wal.rs
+++ b/hiqlite-wal/src/wal.rs
@@ -1,0 +1,470 @@
+use crate::error::Error;
+use crate::metadata::Metadata;
+use crate::utils::{bin_to_id, id_to_bin};
+use std::fs;
+use std::fs::File;
+use std::io::Read;
+
+#[derive(Debug)]
+pub struct WalFile {
+    pub version: u8,
+    pub wal_no: u64,
+    pub path: String,
+    pub id_from: u64,
+    pub id_until: u64,
+}
+
+impl WalFile {
+    #[inline]
+    pub fn new(wal_no: u64, base_path: &str, id_from: u64, id_until: u64) -> Self {
+        debug_assert!(!base_path.is_empty());
+        debug_assert!(id_from <= id_until);
+        let path = Self::build_full_path(base_path, wal_no);
+
+        Self {
+            wal_no,
+            path,
+            version: 1,
+            id_from,
+            id_until,
+        }
+    }
+
+    #[inline]
+    pub fn create_file(&self, wal_size: u32) -> Result<(), Error> {
+        let file = File::create_new(&self.path)?;
+        file.set_len(wal_size as u64)?;
+        Ok(())
+    }
+
+    #[inline]
+    pub fn read_from_file(path_full: String) -> Result<Self, Error> {
+        let Some((_, fname)) = path_full.rsplit_once('/') else {
+            return Err(Error::InvalidPath("Invalid file path"));
+        };
+        let Some((num, ending)) = fname.split_once('.') else {
+            return Err(Error::InvalidPath("Invalid file path"));
+        };
+
+        if ending != "wal" {
+            return Err(Error::InvalidFileName);
+        }
+        let wal_no = num.parse::<u64>()?;
+
+        let mut buf = vec![0; 17];
+        let mut file = File::open(&path_full)?;
+        file.read_exact(&mut buf)?;
+
+        if buf[..1] != [1u8] {
+            return Err(Error::FileCorrupted("Invalid WAL file version"));
+        }
+        let id_from = bin_to_id(&buf[1..9])?;
+        let id_until = bin_to_id(&buf[9..17])?;
+        debug_assert!(id_from < id_until);
+
+        Ok(Self {
+            version: 1,
+            wal_no,
+            path: path_full,
+            id_from,
+            id_until,
+        })
+    }
+
+    #[inline]
+    pub fn write_header(&self, buf: &mut Vec<u8>) -> Result<(), Error> {
+        buf.push(self.version);
+        id_to_bin(self.id_from, buf)?;
+        id_to_bin(self.id_until, buf)?;
+        Ok(())
+    }
+
+    #[inline]
+    pub fn offset_start(&self) -> usize {
+        match self.version {
+            1 => 17,
+            _ => unreachable!(),
+        }
+    }
+
+    #[inline]
+    fn build_full_path(base_path: &str, wal_no: u64) -> String {
+        debug_assert!(!base_path.is_empty());
+
+        let wal_no_str = wal_no.to_string();
+        let zeros = "000000000000000";
+        debug_assert_eq!(zeros.len(), 15);
+        let path = format!(
+            "{}/{}{}.wal",
+            base_path,
+            &zeros[..16 - wal_no_str.len()],
+            wal_no_str
+        );
+        #[cfg(debug_assertions)]
+        {
+            println!("path: {path}");
+            let (base, name) = path.rsplit_once('/').unwrap();
+            debug_assert_eq!(base, base_path);
+            let name = name.strip_suffix(".wal").unwrap();
+            debug_assert_eq!(name.len(), 16);
+        }
+        path
+    }
+}
+
+#[derive(Debug)]
+pub struct WalFileSet<'a> {
+    pub base_path: &'a str,
+    pub headers: Vec<WalFile>,
+}
+
+impl WalFileSet<'_> {
+    #[inline]
+    pub fn active_file(&self) -> &WalFile {
+        debug_assert!(!self.headers.is_empty());
+        if self.headers.len() > 1 {
+            let last = self.headers.last().unwrap();
+            let before = self.headers.get(self.headers.len() - 2).unwrap();
+
+            if before.id_until > 0 && last.id_until == 0 {
+                before
+            } else {
+                last
+            }
+        } else {
+            self.headers.last().unwrap()
+        }
+    }
+
+    pub fn new(base_path: &str) -> WalFileSet {
+        WalFileSet {
+            base_path,
+            headers: Vec::default(),
+        }
+    }
+
+    /// Adds a new `Header` at the end and creates a file for it.
+    pub fn add_header(&mut self, wal_size: u32) -> Result<&WalFile, Error> {
+        let wal_no = if self.headers.is_empty() {
+            1
+        } else {
+            self.headers.last().unwrap().wal_no + 1
+        };
+
+        let header = WalFile::new(wal_no, &self.base_path, 0, 0);
+        header.create_file(wal_size)?;
+        self.headers.push(header);
+
+        Ok(self.headers.last().unwrap())
+    }
+
+    pub fn read(base_path: &str) -> Result<WalFileSet, Error> {
+        let mut headers = Vec::with_capacity(2);
+
+        for entry in fs::read_dir(&base_path)? {
+            let entry = entry?.file_name();
+            let fname = entry.to_str().unwrap_or_default();
+            if fname.ends_with(".wal") {
+                let path_full = format!("{}/{}", base_path, fname);
+                if let Ok(wal) = WalFile::read_from_file(path_full) {
+                    headers.push(wal);
+                }
+            }
+        }
+
+        headers.sort_by(|a, b| a.wal_no.cmp(&b.wal_no));
+        Ok(WalFileSet { base_path, headers })
+    }
+
+    /// Checks the integrity of the Headers and makes sure the order is strictly ascending and
+    /// there are no missing log IDs.
+    pub fn check_integrity(&self, metadata: &Metadata) -> Result<(), Error> {
+        if self.headers.is_empty() {
+            if metadata.log_from != 0 || metadata.log_until != 0 {
+                return Err(Error::FileCorrupted(
+                    "Expected WAL files from Metadata but none found",
+                ));
+            }
+            return Ok(());
+        }
+
+        let mut iter = self.headers.iter();
+
+        let first = iter.next().unwrap();
+        let mut wal_no = first.wal_no;
+        let mut until = first.id_until;
+        if first.id_from > until {
+            return Err(Error::FileCorrupted(
+                "`id_from` cannot be greater than `id_until`",
+            ));
+        }
+        if metadata.log_from < first.id_from {
+            return Err(Error::FileCorrupted(
+                "Metadata expected lower log ID from than found",
+            ));
+        }
+
+        for header in iter {
+            if wal_no + 1 != header.wal_no {
+                return Err(Error::Integrity(
+                    format!("Missing wal file no {}", wal_no + 1).into(),
+                ));
+            }
+            // if there is already a new prepared header at the end, which is no in use yet,
+            // it will have both ids set to 0 until first time use
+            if header.id_from == 0 && header.id_until == 0 {
+                break;
+            }
+            if until + 1 != header.id_from {
+                return Err(Error::Integrity(
+                    format!(
+                        "Missing logs between IDs {} and {}",
+                        until + 1,
+                        header.id_from
+                    )
+                    .into(),
+                ));
+            }
+
+            wal_no = header.wal_no;
+            until = header.id_until;
+        }
+
+        if metadata.log_until > until {
+            Err(Error::FileCorrupted(
+                "Metadata expected higher log ID until than found",
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    const PATH: &str = "test_data";
+
+    #[test]
+    fn convert_wal_header() -> Result<(), Error> {
+        let base_path = format!("{}/convert_wal_header", PATH);
+        let _ = fs::remove_dir_all(&base_path);
+        fs::create_dir_all(&base_path)?;
+
+        let header = WalFile::new(1, &base_path, 23, 1337);
+
+        let mut buf = Vec::with_capacity(18);
+        header.write_header(&mut buf)?;
+
+        // make sure we are cleaned up
+        let path_with_no = format!("{base_path}/0000000000000001.wal");
+        let _ = fs::remove_file(&path_with_no);
+        fs::write(&path_with_no, &buf)?;
+
+        let header_read = WalFile::read_from_file(path_with_no.clone())?;
+
+        assert_eq!(header.version, header_read.version);
+        assert_eq!(header.path, header_read.path);
+        assert_eq!(header.wal_no, header_read.wal_no);
+        assert_eq!(header.id_from, header_read.id_from);
+        assert_eq!(header.id_until, header_read.id_until);
+
+        let path_h1 = format!("{}/0000000000000001.wal", base_path);
+        let path_h2 = format!("{}/0000000000000002.wal", base_path);
+        let _ = fs::remove_file(&path_with_no);
+        let _ = fs::remove_file(&path_h1);
+        let _ = fs::remove_file(&path_h2);
+
+        let mut set = WalFileSet::new(&base_path);
+        set.add_header(8).unwrap();
+        assert_eq!(fs::exists(&path_h1)?, true);
+        assert_eq!(fs::exists(&path_h2)?, false);
+        set.add_header(8).unwrap();
+        assert_eq!(fs::exists(&path_h2)?, true);
+
+        Ok(())
+    }
+
+    #[test]
+    fn integrity_check() -> Result<(), Error> {
+        let base_path = format!("{}/integrity_check", PATH);
+        let _ = fs::remove_dir_all(&base_path);
+        fs::create_dir_all(&base_path)?;
+
+        let meta = Metadata {
+            log_from: 1,
+            log_until: 33,
+            last_purged: None,
+            vote: None,
+        };
+        let mut set = WalFileSet {
+            base_path: &base_path,
+            headers: vec![
+                WalFile {
+                    version: 1,
+                    wal_no: 1,
+                    path: "".to_string(),
+                    id_from: 1,
+                    id_until: 10,
+                },
+                WalFile {
+                    version: 1,
+                    wal_no: 2,
+                    path: "".to_string(),
+                    id_from: 11,
+                    id_until: 17,
+                },
+                WalFile {
+                    version: 1,
+                    wal_no: 3,
+                    path: "".to_string(),
+                    id_from: 18,
+                    id_until: 33,
+                },
+            ],
+        };
+        set.check_integrity(&meta).unwrap();
+        assert_eq!(set.active_file().wal_no, 3);
+
+        set.add_header(8)?;
+        set.check_integrity(&meta).unwrap();
+        assert_eq!(set.active_file().wal_no, 3);
+
+        let set = WalFileSet {
+            base_path: &base_path,
+            headers: vec![
+                WalFile {
+                    version: 1,
+                    wal_no: 1,
+                    path: "".to_string(),
+                    id_from: 1,
+                    id_until: 10,
+                },
+                WalFile {
+                    version: 1,
+                    wal_no: 3,
+                    path: "".to_string(),
+                    id_from: 18,
+                    id_until: 33,
+                },
+            ],
+        };
+        assert!(set.check_integrity(&meta).is_err());
+
+        let set = WalFileSet {
+            base_path: &base_path,
+            headers: vec![
+                WalFile {
+                    version: 1,
+                    wal_no: 1,
+                    path: "".to_string(),
+                    id_from: 1,
+                    id_until: 10,
+                },
+                WalFile {
+                    version: 1,
+                    wal_no: 2,
+                    path: "".to_string(),
+                    id_from: 11,
+                    id_until: 17,
+                },
+                WalFile {
+                    version: 1,
+                    wal_no: 4,
+                    path: "".to_string(),
+                    id_from: 18,
+                    id_until: 33,
+                },
+            ],
+        };
+        assert!(set.check_integrity(&meta).is_err());
+
+        let set = WalFileSet {
+            base_path: &base_path,
+            headers: vec![
+                WalFile {
+                    version: 1,
+                    wal_no: 1,
+                    path: "".to_string(),
+                    id_from: 2,
+                    id_until: 10,
+                },
+                WalFile {
+                    version: 1,
+                    wal_no: 2,
+                    path: "".to_string(),
+                    id_from: 11,
+                    id_until: 17,
+                },
+                WalFile {
+                    version: 1,
+                    wal_no: 3,
+                    path: "".to_string(),
+                    id_from: 18,
+                    id_until: 33,
+                },
+            ],
+        };
+        assert!(set.check_integrity(&meta).is_err());
+
+        let set = WalFileSet {
+            base_path: &base_path,
+            headers: vec![
+                WalFile {
+                    version: 1,
+                    wal_no: 1,
+                    path: "".to_string(),
+                    id_from: 1,
+                    id_until: 10,
+                },
+                WalFile {
+                    version: 1,
+                    wal_no: 2,
+                    path: "".to_string(),
+                    id_from: 11,
+                    id_until: 17,
+                },
+                WalFile {
+                    version: 1,
+                    wal_no: 3,
+                    path: "".to_string(),
+                    id_from: 18,
+                    id_until: 32,
+                },
+            ],
+        };
+        assert!(set.check_integrity(&meta).is_err());
+
+        let set = WalFileSet {
+            base_path: &base_path,
+            headers: vec![
+                WalFile {
+                    version: 1,
+                    wal_no: 1,
+                    path: "".to_string(),
+                    id_from: 1,
+                    id_until: 10,
+                },
+                WalFile {
+                    version: 1,
+                    wal_no: 2,
+                    path: "".to_string(),
+                    id_from: 11,
+                    id_until: 17,
+                },
+                WalFile {
+                    version: 1,
+                    wal_no: 3,
+                    path: "".to_string(),
+                    id_from: 19,
+                    id_until: 33,
+                },
+            ],
+        };
+        assert!(set.check_integrity(&meta).is_err());
+
+        Ok(())
+    }
+}

--- a/hiqlite-wal/src/writer.rs
+++ b/hiqlite-wal/src/writer.rs
@@ -1,0 +1,81 @@
+use crate::error::Error;
+use crate::metadata::Metadata;
+use crate::wal::WalFileSet;
+use memmap2::{Advice, MmapOptions};
+use openraft::{StorageError, StorageIOError};
+use std::collections::VecDeque;
+use std::fs;
+use std::fs::OpenOptions;
+use tokio::sync::oneshot;
+
+pub enum Action {
+    Append {
+        rx: flume::Receiver<Option<(Vec<u8>, Vec<u8>)>>,
+        // TODO with 0.10 the callback will be async ready
+        // callback: LogFlushed<TypeConfigSqlite>,
+        ack: oneshot::Sender<Result<(), StorageIOError<u64>>>,
+    },
+    Remove {
+        from: Vec<u8>,
+        until: Vec<u8>,
+        last_log: Option<Vec<u8>>,
+        ack: oneshot::Sender<Result<(), StorageError<u64>>>,
+    },
+    Vote {
+        value: Vec<u8>,
+        ack: oneshot::Sender<Result<(), StorageIOError<u64>>>,
+    },
+    Sync,
+    Shutdown(oneshot::Sender<()>),
+}
+
+pub fn spawn(
+    base_path: &str,
+    sync_immediate: bool,
+    file_size: u32,
+) -> Result<flume::Sender<Action>, Error> {
+    create_base_path(base_path)?;
+
+    let meta = Metadata::read(base_path)?;
+    let mut set = WalFileSet::read(base_path)?;
+    set.check_integrity(&meta)?;
+    if set.headers.is_empty() {
+        set.add_header(file_size)?;
+    }
+
+    let header = set.headers.last().unwrap();
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        // the file should already exist at this point
+        .create(false)
+        .open(&base_path)?;
+
+    let mut mmap = unsafe { MmapOptions::new().populate().map_mut(&file)? };
+    mmap.advise(Advice::Sequential)?;
+
+    let mut files = VecDeque::with_capacity(2);
+    files.push_front((header, mmap));
+
+    let (tx, rx) = flume::bounded::<Action>(1);
+    // TODO
+    Ok(tx)
+}
+
+fn create_base_path(base_path: &str) -> Result<(), Error> {
+    fs::create_dir_all(base_path)?;
+
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(base_path)?.permissions();
+        perms.set_mode(0o600);
+        fs::set_permissions(base_path, perms)?;
+    }
+
+    Ok(())
+}
+
+fn run() -> Result<(), Error> {
+    todo!()
+}

--- a/hiqlite/src/network/api.rs
+++ b/hiqlite/src/network/api.rs
@@ -232,7 +232,7 @@ async fn handle_socket_concurrent(
         }
     };
 
-    let (tx_write, rx_write) = flume::bounded::<WsWriteMsg>(2);
+    let (tx_write, rx_write) = flume::bounded::<WsWriteMsg>(1);
     // TODO splitting needs `unstable-split` feature right now but is about to be stabilized soon
     let (rx, mut write) = ws.split(tokio::io::split);
     // IMPORTANT: the reader is NOT CANCEL SAFE in v0.8!

--- a/hiqlite/src/network/raft_server.rs
+++ b/hiqlite/src/network/raft_server.rs
@@ -147,7 +147,7 @@ async fn handle_socket(
         return Ok(());
     }
 
-    let (tx_write, rx_write) = flume::bounded::<WsWriteMsg>(2);
+    let (tx_write, rx_write) = flume::bounded::<WsWriteMsg>(1);
     let (rx, mut write) = ws.split(tokio::io::split);
     // IMPORTANT: the reader is NOT CANCEL SAFE in v0.8!
     let mut read = FragmentCollectorRead::new(rx);

--- a/hiqlite/src/server/proxy/stream.rs
+++ b/hiqlite/src/server/proxy/stream.rs
@@ -26,7 +26,7 @@ pub async fn handle_socket(
         return Ok(());
     };
 
-    let (tx_write, rx_write) = flume::bounded::<WsWriteMsg>(2);
+    let (tx_write, rx_write) = flume::bounded::<WsWriteMsg>(1);
     // let (tx_write, rx_write) = flume::unbounded::<WsWriteMsg>();
     // let (tx_read, rx_read) = flume::unbounded();
 

--- a/hiqlite/src/store/state_machine/sqlite/writer.rs
+++ b/hiqlite/src/store/state_machine/sqlite/writer.rs
@@ -136,7 +136,7 @@ pub fn spawn_writer(
     path_lock_file: String,
     log_statements: bool,
 ) -> flume::Sender<WriterRequest> {
-    let (tx, rx) = flume::bounded::<WriterRequest>(2);
+    let (tx, rx) = flume::bounded::<WriterRequest>(1);
 
     // thread::spawn(move || {
     task::spawn_blocking(move || {


### PR DESCRIPTION
The goal of this PR is to create a custom WAL implementation. 

This would solve a few issues:
- `rocksdb` is a very heavy dependency and increased the compile time by a huge margin
- `rocksdb` is almost impossible to compile to `musl` targets
- `rocksdb` is very fast and a very good KV store, but most of it is pure overkill when only being used as a logs store

The main idea is to create a new crate `hiqlite-wal` which will have a custom WAL implementation that exactly matches our use case. There should be an independent writer thread that only cares about writing, creating new WALs, flushing to disk, and so on. It should be possible to spawn multiple reader threads.

Files should probably be `memmap`ed for best performance. The WAL size and therefore `memmap` size should be configurable and log roll over with all dependencies should be handled dynamically, depending on configuration.

At the current stage, the basics for metadata and WAL file headers are implemented incl checksums, but no writer / reader tasks exist yet.