### PR TITLE
Fix: possible race condition when forming a cluster in slower networks

### DIFF
--- a/hiqlite/src/init.rs
+++ b/hiqlite/src/init.rs
@@ -266,7 +266,23 @@ pub async fn become_cluster_member(
     // If we try to become a member too fast and the request arrives on remote directly in between
     // closing and re-opening the socket to us again, and it then also badly overlaps with the raft
     // membership modification, we can get into a deadlock situation on the leader.
-    time::sleep(Duration::from_secs(1)).await;
+    // We want to wait until we are a commited Raft learner.
+    {
+        let mut metrics = helpers::get_raft_metrics(&state, raft_type).await;
+        let mut are_we_learner = metrics
+            .membership_config
+            .nodes()
+            .any(|(id, _)| *id == state.id);
+        while !are_we_learner {
+            info!("We are not a commited learner yet - waiting ...");
+            time::sleep(Duration::from_millis(500)).await;
+            metrics = helpers::get_raft_metrics(&state, raft_type).await;
+            are_we_learner = metrics
+                .membership_config
+                .nodes()
+                .any(|(id, _)| *id == state.id);
+        }
+    }
 
     info!(
         "Node {}: Trying to become {:?} raft member",

--- a/hiqlite/src/init.rs
+++ b/hiqlite/src/init.rs
@@ -274,8 +274,8 @@ pub async fn become_cluster_member(
             .nodes()
             .any(|(id, _)| *id == state.id);
         while !are_we_learner {
-            info!("We are not a commited learner yet - waiting ...");
-            time::sleep(Duration::from_millis(500)).await;
+            info!("Waiting until we are a commited Raft Learner ...");
+            time::sleep(Duration::from_secs(1)).await;
             metrics = helpers::get_raft_metrics(&state, raft_type).await;
             are_we_learner = metrics
                 .membership_config

--- a/hiqlite/src/init.rs
+++ b/hiqlite/src/init.rs
@@ -263,6 +263,11 @@ pub async fn become_cluster_member(
         raft_type.as_str()
     );
 
+    // If we try to become a member too fast and the request arrives on remote directly in between
+    // closing and re-opening the socket to us again, and it then also badly overlaps with the raft
+    // membership modification, we can get into a deadlock situation on the leader.
+    time::sleep(Duration::from_secs(1)).await;
+
     info!(
         "Node {}: Trying to become {:?} raft member",
         state.id, raft_type

--- a/hiqlite/src/network/raft_client.rs
+++ b/hiqlite/src/network/raft_client.rs
@@ -209,10 +209,6 @@ impl NetworkStreaming {
             usize,
             oneshot::Sender<Result<RaftStreamResponsePayload, Error>>,
         > = HashMap::with_capacity(8);
-        // let mut in_flight: Vec<(
-        //     usize,
-        //     oneshot::Sender<Result<RaftStreamResponsePayload, Error>>,
-        // )> = Vec::with_capacity(8);
         let mut shutdown = false;
 
         loop {

--- a/hiqlite/src/split_brain_check.rs
+++ b/hiqlite/src/split_brain_check.rs
@@ -7,7 +7,7 @@ use std::env;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::{task, time};
-use tracing::{error, info, warn};
+use tracing::{debug, error, warn};
 
 pub fn spawn(state: Arc<AppState>, nodes: Vec<Node>, tls: bool) {
     let handle = task::spawn(check_split_brain(state, nodes, tls));
@@ -37,7 +37,7 @@ async fn check_split_brain(state: Arc<AppState>, nodes: Vec<Node>, tls: bool) {
                 warn!("Node {}: No leader for DB", state.id);
             }
             Some(leader_expected) => {
-                info!("Node {}: Raft DB Leader: {}", state.id, leader_expected);
+                debug!("Node {}: Raft DB Leader: {}", state.id, leader_expected);
                 let metrics = state.raft_db.raft.metrics().borrow().clone();
                 let membership = metrics.membership_config;
 
@@ -65,7 +65,7 @@ async fn check_split_brain(state: Arc<AppState>, nodes: Vec<Node>, tls: bool) {
                 warn!("Node {}: No leader for Cache", state.id);
             }
             Some(leader_expected) => {
-                info!("Node {}: Raft Cache Leader: {}", state.id, leader_expected);
+                debug!("Node {}: Raft Cache Leader: {}", state.id, leader_expected);
                 let metrics = state.raft_cache.raft.metrics().borrow().clone();
                 let membership = metrics.membership_config;
 


### PR DESCRIPTION
This PR brings a dynamic "wait until we are a commited member" to automated cluster joins. This avoid possible Raft deadlocks because of race conditions in environments like e.g. Kubernetes, where it takes a few seconds until a headless service picks up new pods. 

After a node joins on remote as a new learner, the remote node will open a connection to the newly joined one and replicate the state. If you are using any type of service discovery, it usually takes a few seconds until new services are reachable. If you now modify the state multiple times before the remote node had a chance to connect, and node enough nodes are in the cluster yet to achieve a quorum on the new raft state, you can end up in a dead lock. This is especially very likely when you cold start a fresh cluster and the first node joins.

The dynamic check and wait solves this issue and will only trigger the 2nd step after the change has been committed.