### PR TITLE
Fix: respect `RaftRequest::Shutdown` between connection attempts in Raft Client

### DIFF
--- a/hiqlite/src/network/raft_client.rs
+++ b/hiqlite/src/network/raft_client.rs
@@ -245,7 +245,10 @@ impl NetworkStreaming {
                                 #[cfg(feature = "cache")]
                                 RaftRequest::SnapshotCache((ack, _)) => Some(ack),
                                 RaftRequest::StreamResponse(_) => None,
-                                RaftRequest::Shutdown => None,
+                                RaftRequest::Shutdown => {
+                                    shutdown = true;
+                                    None
+                                }
                             };
 
                             if let Some(ack) = ack {
@@ -255,6 +258,9 @@ impl NetworkStreaming {
                                 ))));
                             }
                         });
+                        if shutdown {
+                            break;
+                        }
 
                         // if there is a network error, don't try too hard to connect
                         // time::sleep(Duration::from_millis(heartbeat_interval * 3)).await;


### PR DESCRIPTION
This is the last fix for the stability issues. The Shutdown message to the Raft Streaming Client was not respected between connection attempts, which made the Drop impl block for forever and caused the locking when an offline Node should have been removed from the whole cluster.

This finally fixes in-memory only caches and makes them perfectly stable.
