### PR TITLE
Feat: implement distributed counters

### DIFF
--- a/hiqlite-wal/src/reader.rs
+++ b/hiqlite-wal/src/reader.rs
@@ -60,15 +60,28 @@ fn run(
                 }
 
                 let mut from_next = from;
-                for log in wal.files.iter_mut() {
-                    if from_next < log.id_from {
-                        error!(
-                            "Mismatch in Log IDs - Should read from {from_next} while this log \
-                        starts later {:?}",
-                            log,
+                // TODO this checked issue can happen for a real deployment, if a cluster is being
+                //  restarted and resynced after a crash or shutdown of all 3 nodes at once, if the
+                //  very first raft actions comes too quick. This is a race condition.
+                //  -> find a nice way to check for this case before returning the `Client`
+                //     in `start` to never let this be possible, if someone immediately interacts
+                //     with the Raft weil getting into this unlucky situation
+                //  -> not 100% yet where the root cause for this might be, but probably if
+                //     interaction starts before the node had a chance to fully resync. We could
+                //     probably wait for a node to reach a stable point somehow by comparing
+                //     metrics or raft log lag
+                #[cfg(debug_assertions)]
+                {
+                    let first = wal.files.get(0).unwrap();
+                    if from_next < first.id_from {
+                        panic!(
+                            "Mismatch in Log IDs - Should read from {from_next} until {until} while the first \
+                            log starts later: {}\n{:?}",
+                            first.id_from, wal.files
                         );
                     }
-
+                }
+                for log in wal.files.iter_mut() {
                     if log.id_until < from_next {
                         debug!(
                             "log.id_until < from_next -> {} < {}",

--- a/hiqlite-wal/src/reader.rs
+++ b/hiqlite-wal/src/reader.rs
@@ -72,7 +72,7 @@ fn run(
                 //     metrics or raft log lag
                 #[cfg(debug_assertions)]
                 {
-                    let first = wal.files.get(0).unwrap();
+                    let first = wal.files.front().unwrap();
                     if from_next < first.id_from {
                         panic!(
                             "Mismatch in Log IDs - Should read from {from_next} until {until} while the first \

--- a/hiqlite-wal/src/writer.rs
+++ b/hiqlite-wal/src/writer.rs
@@ -188,7 +188,7 @@ fn run(
                 last_log,
                 ack,
             } => {
-                warn!(
+                debug!(
                     "WAL Writer - Action::Remove from {from} until {until} / last_log: {:?}\n{:?}",
                     last_log, wal
                 );

--- a/hiqlite-wal/src/writer.rs
+++ b/hiqlite-wal/src/writer.rs
@@ -183,12 +183,15 @@ fn run(
                 }
             }
             Action::Remove {
-                from: _,
+                from,
                 until,
                 last_log,
                 ack,
             } => {
-                debug!("WAL Writer - Action::Remove");
+                warn!(
+                    "WAL Writer - Action::Remove from {from} until {until} / last_log: {:?}\n{:?}",
+                    last_log, wal
+                );
 
                 // We don't care about the `from` part, since we don't really delete anything yet.
                 // We only want to shift the index inside the WALs and only delete complete WAL

--- a/hiqlite/Cargo.toml
+++ b/hiqlite/Cargo.toml
@@ -24,6 +24,7 @@ auto-heal = ["hiqlite-wal/auto-heal"]
 backup = ["dep:cron", "s3", "sqlite"]
 # TODO check why we need the "openraft/loosen-follower-log-revert" here -> conflict in self-healing tests
 cache = ["openraft/loosen-follower-log-revert"]
+counters = ["cache"]
 dashboard = [
     "dep:argon2",
     "dep:axum-extra",

--- a/hiqlite/src/helpers.rs
+++ b/hiqlite/src/helpers.rs
@@ -25,45 +25,14 @@ pub async fn is_raft_initialized(
     state: &Arc<AppState>,
     raft_type: &RaftType,
 ) -> Result<bool, Error> {
-    match raft_type {
+    let is_initialized = match raft_type {
         #[cfg(feature = "sqlite")]
-        RaftType::Sqlite => {
-            if !state.raft_db.raft.is_initialized().await? {
-                let members = get_raft_metrics(state, raft_type).await.membership_config;
-                if members.membership().nodes().count() > 0 {
-                    Ok(true)
-                } else {
-                    Ok(false)
-                }
-            } else {
-                let members = get_raft_metrics(state, raft_type).await.membership_config;
-                if members.membership().nodes().count() > 0 {
-                    Ok(true)
-                } else {
-                    Ok(false)
-                }
-            }
-        }
+        RaftType::Sqlite => state.raft_db.raft.is_initialized().await?,
         #[cfg(feature = "cache")]
-        RaftType::Cache => {
-            if !state.raft_cache.raft.is_initialized().await? {
-                let members = get_raft_metrics(state, raft_type).await.membership_config;
-                if members.membership().nodes().count() > 0 {
-                    Ok(true)
-                } else {
-                    Ok(false)
-                }
-            } else {
-                let members = get_raft_metrics(state, raft_type).await.membership_config;
-                if members.membership().nodes().count() > 0 {
-                    Ok(true)
-                } else {
-                    Ok(false)
-                }
-            }
-        }
+        RaftType::Cache => state.raft_cache.raft.is_initialized().await?,
         RaftType::Unknown => panic!("neither `sqlite` nor `cache` feature enabled"),
-    }
+    };
+    Ok(is_initialized)
 }
 
 #[inline]

--- a/hiqlite/src/helpers.rs
+++ b/hiqlite/src/helpers.rs
@@ -29,8 +29,6 @@ pub async fn is_raft_initialized(
         #[cfg(feature = "sqlite")]
         RaftType::Sqlite => {
             if !state.raft_db.raft.is_initialized().await? {
-                // We might have an initialized Raft from old ticks, but still be in an
-                // un-initialized state with no members after a volume loss
                 let members = get_raft_metrics(state, raft_type).await.membership_config;
                 if members.membership().nodes().count() > 0 {
                     Ok(true)
@@ -38,48 +36,17 @@ pub async fn is_raft_initialized(
                     Ok(false)
                 }
             } else {
-                /*
-                We can get in a tricky situation here.
-                In most cases, the `.is_initialized()` gives just the information we want.
-                But, if *this* node lost its volume and therefore membership state, and another
-                leader is still running and trying to reach *this* node before it can fully start
-                up (race condition), the raft will report being initialized via this check, while
-                it actually is not, because it lost all its state.
-                If we get into this situation, we will have a committed leader vote, but no other
-                data like logs and membership config.
-                 */
-
-                let metrics = state.raft_db.raft.server_metrics().borrow().clone();
-
-                #[cfg(debug_assertions)]
-                if metrics.current_leader.is_none()
-                    && metrics.vote.leader_id().node_id == state.id
-                    && metrics.vote.committed
-                {
-                    panic!(
-                        "current_leader.is_none() && metrics.vote.leader_id().node_id == \
-                        state.id && metrics.vote.committed:\n{:?}",
-                        metrics
-                    )
-                }
-
-                if metrics.vote.committed
-                    && metrics.vote.leader_id.node_id != state.id
-                    && metrics.current_leader.is_none()
-                {
-                    // If we get here, we have a race condition and a remote leader initialized this
-                    // node after a data volume loss before it had a change to re-join and sync data.
-                    Ok(false)
-                } else {
+                let members = get_raft_metrics(state, raft_type).await.membership_config;
+                if members.membership().nodes().count() > 0 {
                     Ok(true)
+                } else {
+                    Ok(false)
                 }
             }
         }
         #[cfg(feature = "cache")]
         RaftType::Cache => {
             if !state.raft_cache.raft.is_initialized().await? {
-                // We might have an initialized Raft from old ticks, but still be in an
-                // un-initialized state with no members after a volume loss
                 let members = get_raft_metrics(state, raft_type).await.membership_config;
                 if members.membership().nodes().count() > 0 {
                     Ok(true)
@@ -87,40 +54,11 @@ pub async fn is_raft_initialized(
                     Ok(false)
                 }
             } else {
-                /*
-                We can get in a tricky situation here.
-                In most cases, the `.is_initialized()` gives just the information we want.
-                But, if *this* node lost its volume and therefore membership state, and another
-                leader is still running and trying to reach *this* node before it can fully start
-                up (race condition), the raft will report being initialized via this check, while
-                it actually is not, because it lost all its state.
-                If we get into this situation, we will have a committed leader vote, but no other
-                data like logs and membership config.
-                 */
-
-                let metrics = state.raft_cache.raft.server_metrics().borrow().clone();
-
-                #[cfg(debug_assertions)]
-                if metrics.current_leader.is_none()
-                    && metrics.vote.leader_id().node_id == state.id
-                    && metrics.vote.committed
-                {
-                    panic!(
-                        "current_leader.is_none() && metrics.vote.leader_id().node_id == \
-                        state.id && metrics.vote.committed:\n{:?}",
-                        metrics
-                    )
-                }
-
-                if metrics.vote.committed
-                    && metrics.vote.leader_id.node_id != state.id
-                    && metrics.current_leader.is_none()
-                {
-                    // If we get here, we have a race condition and a remote leader initialized this
-                    // node after a data volume loss before it had a change to re-join and sync data.
-                    Ok(false)
-                } else {
+                let members = get_raft_metrics(state, raft_type).await.membership_config;
+                if members.membership().nodes().count() > 0 {
                     Ok(true)
+                } else {
+                    Ok(false)
                 }
             }
         }

--- a/hiqlite/src/server/proxy/stream.rs
+++ b/hiqlite/src/server/proxy/stream.rs
@@ -65,17 +65,6 @@ pub async fn handle_socket(
             }
         }
 
-        // warn!("emptying server stream writer channel into buffer");
-        // while let Ok(req) = rx_write.recv_async().await {
-        //     if let WsWriteMsg::Payload(resp) = req {
-        //         let payload = bincode::serialize(&resp).unwrap();
-        //         buf_tx
-        //             .send_async(payload)
-        //             .await
-        //             .expect("client_buffer to always be working");
-        //     }
-        // }
-
         warn!("server stream exiting");
     });
 

--- a/hiqlite/tests/cluster/cache.rs
+++ b/hiqlite/tests/cluster/cache.rs
@@ -143,6 +143,24 @@ pub async fn test_cache(
 
     insert_test_value_cache(client_1).await?;
 
+    log("Test Counters");
+    let key = "counter1";
+    client_1.counter_set(Cache::One, key, 13).await?;
+    let v = client_1.counter_get(Cache::One, key).await?;
+    assert_eq!(v.unwrap(), 13);
+    let v = client_1.counter_get(Cache::Two, key).await?;
+    assert!(v.is_none());
+
+    client_1.counter_set(Cache::One, key, -17).await?;
+    let v = client_1.counter_get(Cache::One, key).await?;
+    assert_eq!(v.unwrap(), -17);
+
+    let v = client_1.counter_add(Cache::One, key, 19).await?;
+    assert_eq!(v, 2);
+
+    let v = client_1.counter_add(Cache::One, key, -3).await?;
+    assert_eq!(v, -1);
+
     Ok(())
 }
 

--- a/hiqlite/tests/cluster/main.rs
+++ b/hiqlite/tests/cluster/main.rs
@@ -158,8 +158,9 @@ async fn exec_tests() -> Result<(), Error> {
     start::wait_for_healthy_cluster(&client_1, &client_2, &client_3).await?;
     log("Cluster is healthy again");
 
-    // give caches some additional time to re-sync
-    time::sleep(Duration::from_millis(250)).await;
+    // TODO if this next action comes too fast, there will be a WAL log ID mismatch
+    //  -> find out why and fix it
+    time::sleep(Duration::from_millis(1000)).await;
     cache::insert_test_value_cache(&client_1).await?;
 
     log("Make sure all data is ok");

--- a/hiqlite/tests/cluster/main.rs
+++ b/hiqlite/tests/cluster/main.rs
@@ -68,6 +68,8 @@ async fn test_cluster() {
     unsafe { env::remove_var("HQL_BACKUP_RESTORE") };
     let _ = fs::remove_dir_all(TEST_DATA_DIR);
 
+    dotenvy::from_filename("../config").ok();
+
     let tracing_layer = tracing_subscriber::fmt::layer()
         .with_target(true)
         .with_thread_ids(true)
@@ -156,6 +158,8 @@ async fn exec_tests() -> Result<(), Error> {
     start::wait_for_healthy_cluster(&client_1, &client_2, &client_3).await?;
     log("Cluster is healthy again");
 
+    // give caches some additional time to re-sync
+    time::sleep(Duration::from_millis(250)).await;
     cache::insert_test_value_cache(&client_1).await?;
 
     log("Make sure all data is ok");

--- a/justfile
+++ b/justfile
@@ -95,6 +95,7 @@ clippy:
     cargo clippy --no-default-features --features sqlite,auto-heal,backup
 
     cargo clippy --no-default-features --features cache
+    cargo clippy --no-default-features --features counters
     cargo clippy --no-default-features --features dlock
     cargo clippy --no-default-features --features listen_notify_local
     cargo clippy --no-default-features --features listen_notify
@@ -126,7 +127,7 @@ test:
     set -euxo pipefail
     clear
     # we need to run the tests with nightly to not get an error for docs auto cfg
-    RUSTFLAGS="--cfg tokio_unstable" cargo +nightly test --features cache,dlock,listen_notify
+    RUSTFLAGS="--cfg tokio_unstable" cargo +nightly test --features cache,counters,dlock,listen_notify
 
 # builds the code
 build ty="server":


### PR DESCRIPTION
This PR provides distributed counters. They use a `String` as their index to make them fully dynamic and things possible like implement rate-limiting by IP or some headers names for instance. Each `CacheIndex` has its own set of counters and they don't interfere, even if their keys overlap.