### PR TITLE
Feat: improve WAL record recovery after panic

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,7 @@ and self-healing capabilities in case of any errors or problems.
 - persistent storage for Raft logs (with [rocksdb](https://github.com/rust-rocksdb/rust-rocksdb)) and SQLite state
   machine
 - "magic" auto setup, no need to do any manual init or management for the Raft
-- self-healing - each node can automatically recover from un-graceful shutdowns ~~and even full data volume loss~~
-  (Note: There is a known bug that sometimes can lead to a Raft lock, if the full volume has been lost. This can be
-  fixed, but needs manual interaction and a cluster restart right now)
+- self-healing - each node can automatically recover from un-graceful shutdowns and even full data volume loss
 - automatic database migrations
 - fully authenticated networking
 - optional TLS everywhere for a zero-trust philosophy

--- a/hiqlite/src/config.rs
+++ b/hiqlite/src/config.rs
@@ -352,7 +352,7 @@ impl NodeConfig {
             enc_keys: self.enc_keys.enc_keys.clone(),
         };
         if cloned.init().is_err() {
-            warn!("Cannot initialize ENC_KEYS - already initialized");
+            debug!("Cannot initialize ENC_KEYS - already initialized");
         }
     }
 

--- a/hiqlite/src/store/state_machine/memory/state_machine.rs
+++ b/hiqlite/src/store/state_machine/memory/state_machine.rs
@@ -24,8 +24,6 @@ use std::sync::Arc;
 use strum::IntoEnumIterator;
 use tokio::fs;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-#[cfg(unix)]
-use tokio::net::unix::pipe::OpenOptions;
 use tokio::sync::{oneshot, Mutex, RwLock};
 use tokio::task;
 use tracing::{debug, info, warn};


### PR DESCRIPTION
This PR brings quite an improvement compared to `rocksdb` before.

The new `hiqlite-wal` implementation is not able to recover orphaned WAL records, that may have been in buffers right before an application crashed, and it was not possible to flush these buffers to disk. This is something that can happen to every database, when something really bad happens in the middle of an operation, or if it's force-killed.

I used Rauthy with automated and timed `panic`s to produce these errors consistently and improved the WAL recovery mechanism. Hiqlite now does a deep integrity check automatically on startup, if it finds an existing lock file and therefore knows, that it must have been an ungraceful shutdown before. This deep check iterates over the full latest WAL log (all other ones before can only have been flushed properly, if a later one exists).
It checks the CRC for each record it finds and compares the log id to its own metadata header. In this phase, either all logs are fine, or there is a CRC mismatch. In case of a mismatch, it will roll back the metadata to the latest healthy Log ID, so that the node can re-sync the missing logs from other cluster members. If all expected logs are checked and okay though, it will go into a 2nd phase, where it peeks into the data that is not referenced by the metadata header and looks for orphaned logs. It recovers as many of them as possible, as long as their CRC matches as well, and updates the metadata for each one of them.

This works really well with this PR in all my tests. There is now only a single situation left you could get into, that needs manual interaction, but this can only happen if you have a nicely timed force-kill or app crash during the initialization of a fresh cluster. The membership join is done in multiple steps and if it crashes after beginning it but before finishing it, the latest membership may contain no members, but still report being initiailized. In this case, you currently only have the option to reset the WAL, but it can only happen at the very beginning of a fresh cluster, and only once.