### PR TITLE
move the `rocksdb-migrate` feature check

### DIFF
--- a/hiqlite/src/lib.rs
+++ b/hiqlite/src/lib.rs
@@ -4,11 +4,6 @@
 #![forbid(unsafe_code)]
 #![cfg_attr(doc, feature(doc_auto_cfg))]
 
-#[cfg(all(feature = "rocksdb", feature = "migrate-rocksdb"))]
-compile_error!(
-    "Feature `migrate-rocksdb` only makes sense when `rocksdb` is not used as logs store"
-);
-
 #[cfg(all(feature = "jemalloc", not(target_env = "msvc")))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;

--- a/hiqlite/src/store/logs/migrate.rs
+++ b/hiqlite/src/store/logs/migrate.rs
@@ -24,6 +24,9 @@ pub async fn check_migrate_rocksdb(
     wal_size: u32,
     wal_ignore_lock: bool,
 ) -> Result<(), Error> {
+    #[cfg(feature = "rocksdb")]
+    panic!("Feature `migrate-rocksdb` only makes sense when `rocksdb` is not used as logs store");
+
     // the bare minimum of files that must be there for a possibly existing
     // rocksdb is a `LOG` file
     if !fs::try_exists(format!("{}/LOG", logs_dir)).await? {


### PR DESCRIPTION
Moving the check if `rocksdb` and `migrate-rocksdb` feature are enabled at the same time into another location instead opf throwing a `compile_error`. This fixes the issue that `docs.rs` cannot build the documentation with the `--all-features` enabled.