### PR TITLE
Feat: implement cross-platform file locking and improve WAL locking + recovery

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ fastwebsockets = { version = "0.10.0", features = [
     "unstable-split",
 ] }
 flume = "0.11.0"
+fs4 = { version = "0.13.1", features = ["sync"] }
 futures-util = "0.3.30"
 getrandom = { version = "0.3", features = ["std"] }
 hex = "0.4.3"

--- a/hiqlite-wal/Cargo.toml
+++ b/hiqlite-wal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hiqlite-wal"
-version = "0.7.1"
+version = "0.8.0-20250616"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -25,6 +25,7 @@ bincode.workspace = true
 byteorder.workspace = true
 crc.workspace = true
 flume.workspace = true
+fs4.workspace = true
 memmap2.workspace = true
 openraft.workspace = true
 serde.workspace = true

--- a/hiqlite-wal/src/lib.rs
+++ b/hiqlite-wal/src/lib.rs
@@ -8,6 +8,7 @@ pub use shutdown::ShutdownHandle;
 pub use writer::Action;
 
 pub mod error;
+mod lockfile;
 mod log_store;
 mod log_store_impl;
 mod metadata;

--- a/hiqlite-wal/src/lockfile.rs
+++ b/hiqlite-wal/src/lockfile.rs
@@ -1,0 +1,99 @@
+use crate::error::Error;
+use fs4::fs_std::FileExt;
+use std::fs::{self, File, OpenOptions};
+
+#[derive(Debug)]
+pub struct LockFile {
+    file: File,
+}
+
+impl LockFile {
+    #[inline]
+    pub fn exists(base_path: &str) -> Result<bool, Error> {
+        Ok(fs::exists(Self::path(base_path))?)
+    }
+
+    pub fn create(base_path: &str) -> Result<Self, Error> {
+        let path = Self::path(base_path);
+
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&path)
+            .map_err(|err| {
+                Error::Internal(format!("Cannot create WAL lock file {}: {}", path, err).into())
+            })?;
+
+        Ok(Self { file })
+    }
+
+    pub fn is_locked(base_path: &str) -> Result<bool, Error> {
+        let path = Self::path(base_path);
+        let file = File::open(path)?;
+        let is_locked = Self::lock_file(&file).is_err();
+        Ok(is_locked)
+    }
+
+    pub fn lock(&self) -> Result<(), Error> {
+        Self::lock_file(&self.file)
+    }
+
+    fn lock_file(file: &File) -> Result<(), Error> {
+        match file.try_lock_exclusive() {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(Error::Internal(
+                "WAL lock file is in use by another process".into(),
+            )),
+            Err(err) => Err(Error::Internal(
+                format!("Error locking WAL lock file: {}", err).into(),
+            )),
+        }
+    }
+
+    /// Will not work if the locked `LockFile` was not dropped before.
+    pub fn remove(base_path: &str) -> Result<(), Error> {
+        fs::remove_file(Self::path(base_path))?;
+        Ok(())
+    }
+
+    #[inline]
+    fn path(base_path: &str) -> String {
+        format!("{base_path}/lock.hql")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PATH: &str = "test_data";
+
+    #[test]
+    fn lockfile() {
+        let base_path = format!("{}/lockfile", PATH);
+        let _ = fs::remove_dir_all(&base_path);
+        fs::create_dir_all(&base_path).unwrap();
+
+        assert!(!LockFile::exists(&base_path).unwrap());
+        let file = LockFile::create(&base_path).unwrap();
+        assert!(LockFile::exists(&base_path).unwrap());
+
+        assert!(!LockFile::is_locked(&base_path).unwrap());
+        file.lock().unwrap();
+        assert!(LockFile::is_locked(&base_path).unwrap());
+
+        // make sure it's still locked even if we create a new file
+        let file_new = LockFile::create(&base_path).unwrap();
+        assert!(LockFile::is_locked(&base_path).unwrap());
+        drop(file_new);
+
+        LockFile::remove(&base_path).unwrap();
+
+        assert!(LockFile::is_locked(&base_path).is_err());
+        // create a new one, it should not be locked anymore
+        let _file = LockFile::create(&base_path).unwrap();
+        assert!(!LockFile::is_locked(&base_path).unwrap());
+    }
+}

--- a/hiqlite-wal/src/metadata.rs
+++ b/hiqlite-wal/src/metadata.rs
@@ -92,64 +92,11 @@ impl Metadata {
     }
 }
 
-pub struct LockFile;
-
-impl LockFile {
-    #[inline]
-    pub fn exists(base_path: &str) -> Result<bool, Error> {
-        Ok(fs::exists(Self::path(base_path))?)
-    }
-
-    pub fn write(base_path: &str, wal_ignore_lock: bool) -> Result<(), Error> {
-        let path = Self::path(base_path);
-        match File::open(&path) {
-            Ok(_) => {
-                if wal_ignore_lock {
-                    Ok(())
-                } else {
-                    Err(Error::Locked(
-                        "WAL is locked, take a look at `HQL_WAL_IGNORE_LOCK`",
-                    ))
-                }
-            }
-            Err(_) => {
-                File::create(path)?;
-                Ok(())
-            }
-        }
-    }
-
-    pub fn remove(base_path: &str) -> Result<(), Error> {
-        let path = format!("{base_path}/lock.hql");
-        fs::remove_file(path)?;
-        Ok(())
-    }
-
-    #[inline]
-    fn path(base_path: &str) -> String {
-        format!("{base_path}/lock.hql")
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     const PATH: &str = "test_data";
-
-    #[test]
-    fn lockfile() -> Result<(), Error> {
-        LockFile::write(&PATH, false)?;
-        assert!(LockFile::write(&PATH, false).is_err());
-        LockFile::remove(&PATH)?;
-
-        LockFile::write(&PATH, false)?;
-        assert!(LockFile::write(&PATH, false).is_err());
-        assert!(LockFile::write(&PATH, true).is_ok());
-        LockFile::remove(&PATH)?;
-
-        Ok(())
-    }
 
     #[test]
     fn metadata_write_read() -> Result<(), Error> {

--- a/hiqlite-wal/src/wal.rs
+++ b/hiqlite-wal/src/wal.rs
@@ -745,7 +745,7 @@ impl WalFileSet {
     pub fn check_integrity(
         &mut self,
         buf: &mut Vec<u8>,
-        lock_file_exists: bool,
+        wal_deep_integrity_check: bool,
     ) -> Result<(), Error> {
         if self.files.is_empty() {
             return Ok(());
@@ -819,7 +819,7 @@ impl WalFileSet {
             .unwrap_or("false")
             .parse::<bool>()
             .expect("Cannot parse HQL_CHECK_WAL_INTEGRITY as bool");
-        if lock_file_exists || check {
+        if wal_deep_integrity_check || check {
             let active = self.active();
             if active.mmap_mut.is_none() {
                 active.mmap_mut()?;

--- a/hiqlite.toml
+++ b/hiqlite.toml
@@ -312,32 +312,6 @@ password_dashboard = "JGFyZ29uMmlkJHY9MTkkbT0zMix0PTIscD0xJE9FbFZURnAwU0V0bFJ6ZF
 # overwritten by: HQL_INSECURE_COOKIE
 insecure_cookie = true
 
-# Can be set to true to start the WAL handler even if the
-# `lock.hql` file exists. This may be necessary after a
-# crash, when the lock file could not be removed during a
-# graceful shutdown.
-#
-# IMPORTANT: Even though the Database can "heal" itself by
-# simply rebuilding from the existing Raft log files without
-# even needing to think about it, you may want to only
-# set `HQL_WAL_IGNORE_LOCK` when necessary to have more
-# control. Depending on the type of crash (whole OS, maybe
-# immediate power loss, force killed, ...), it may be the
-# case that the WAL files + metadata could not be synced
-# to disk properly and that quite a bit of data is lost.
-#
-# In such a case, it is usually a better idea to delete
-# the whole volume and let the broken node rebuild from
-# other healthy cluster members, just to be sure.
-#
-# However, you can decide to ignore the lock file and start
-# anyway. But you must be 100% sure, that no orphaned
-# process is still running and accessing the WAL files!
-#
-# default: false
-# overwritten by: HQL_WAL_IGNORE_LOCK
-#wal_ignore_lock = true
-
 # You can reset the Raft Logs + Metadata when set to
 # `true`. This can be helpful, if you e.g. run a single
 # instance "cluster" and encountered an unrecoverable

--- a/hiqlite/src/config_toml.rs
+++ b/hiqlite/src/config_toml.rs
@@ -122,8 +122,6 @@ impl NodeConfig {
         };
         let wal_size =
             t_u32(&mut map, t_name, "wal_size", "HQL_WAL_SIZE").unwrap_or(2 * 1024 * 1024);
-        let wal_ignore_lock =
-            t_bool(&mut map, t_name, "wal_ignore_lock", "HQL_WAL_IGNORE_LOCK").unwrap_or(false);
 
         #[cfg(feature = "cache")]
         let cache_storage_disk = t_bool(
@@ -273,7 +271,6 @@ impl NodeConfig {
             sync_immediate: false,
             wal_sync,
             wal_size,
-            wal_ignore_lock,
             #[cfg(feature = "cache")]
             cache_storage_disk,
             raft_config: NodeConfig::default_raft_config(logs_until_snapshot),

--- a/hiqlite/src/store/logs/migrate.rs
+++ b/hiqlite/src/store/logs/migrate.rs
@@ -19,11 +19,7 @@ static KEY_VOTE: &[u8] = b"vote";
 /// Checks if `rocksdb` files are in the target folder and tries to perform a migration from
 /// rocksdb to `hiqlite-wal` in that case.
 #[tracing::instrument]
-pub async fn check_migrate_rocksdb(
-    logs_dir: String,
-    wal_size: u32,
-    wal_ignore_lock: bool,
-) -> Result<(), Error> {
+pub async fn check_migrate_rocksdb(logs_dir: String, wal_size: u32) -> Result<(), Error> {
     #[cfg(feature = "rocksdb")]
     panic!("Feature `migrate-rocksdb` only makes sense when `rocksdb` is not used as logs store");
 
@@ -55,12 +51,9 @@ pub async fn check_migrate_rocksdb(
         }
 
         info!("starting hiqlite-wal writer for migration");
-        let writer = LogStore::<TypeConfigSqlite>::start_writer_migration(
-            logs_dir.clone(),
-            wal_size,
-            wal_ignore_lock,
-        )
-        .await?;
+        let writer =
+            LogStore::<TypeConfigSqlite>::start_writer_migration(logs_dir.clone(), wal_size)
+                .await?;
         task::spawn_blocking(move || async {
             if let Err(err) = migrate(db, writer).await {
                 panic!("Cannot migrate from rocksdb: {:?}", err);

--- a/hiqlite/src/store/mod.rs
+++ b/hiqlite/src/store/mod.rs
@@ -49,7 +49,6 @@ pub(crate) async fn start_raft_db(
     logs::migrate::check_migrate_rocksdb(
         logs::logs_dir_db(&node_config.data_dir),
         node_config.wal_size,
-        node_config.wal_ignore_lock,
     )
     .await?;
 
@@ -62,7 +61,6 @@ pub(crate) async fn start_raft_db(
         logs::logs_dir_db(&node_config.data_dir),
         node_config.wal_sync.clone(),
         node_config.wal_size,
-        node_config.wal_ignore_lock,
     )
     .await?;
     let state_machine_store = StateMachineSqlite::new(
@@ -172,7 +170,6 @@ where
             logs::logs_dir_cache(&node_config.data_dir),
             node_config.wal_sync.clone(),
             node_config.wal_size,
-            node_config.wal_ignore_lock,
         )
         .await?;
         let shutdown_handle = log_store.shutdown_handle();


### PR DESCRIPTION
This PR brings huge improvements to WAL locking:

- file-locking is now cross-platform and has multiple levels
- if a file is actively locked - `panic` on startup because of in use by another process
- locks are dropped when the process exits
- lockfile is removed during a graceful / clean shutdown
- if a lockfile exists at startup without being locked -> unclean start -> trigger deep WAL integrity check
- the `wal_ignore_lock` config variable was removed completely, because `hiqlite-wal` can solve all situations automatically now