### PR TITLE
Even cache only data_dir must exist

### DIFF
--- a/hiqlite.toml
+++ b/hiqlite.toml
@@ -41,6 +41,8 @@ listen_addr_api = "0.0.0.0"
 listen_addr_raft = "0.0.0.0"
 
 # The data dir hiqlite will store raft logs and state machine data in.
+# `data_dir` must exist and be writable, even if cache only is used!
+# See also `cache_storage_disk`.
 #
 # default: data
 # overwritten by: HQL_DATA_DIR
@@ -141,6 +143,7 @@ wal_size = 2097152
 # all your cached data will be gone.
 # In-memory only hugegly increases the throughput though, so it
 # depends on your needs, what you should prefer.
+# See also `data_dir`.
 #
 # default: true
 # overwritten by: HQL_CACHE_STORAGE_DISK

--- a/hiqlite/src/error.rs
+++ b/hiqlite/src/error.rs
@@ -88,6 +88,9 @@ pub enum Error {
     WAL(String),
     #[error("WebSocket: {0}")]
     WebSocket(String),
+    #[cfg(feature = "toml")]
+    #[error("Error: {0}")]
+    String(String),
 }
 
 impl Error {
@@ -158,6 +161,8 @@ impl IntoResponse for Error {
             Error::Unauthorized(_) => StatusCode::UNAUTHORIZED,
             Error::WAL(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Error::WebSocket(_) => StatusCode::BAD_REQUEST,
+            #[cfg(feature = "toml")]
+            Error::String(_) => StatusCode::INTERNAL_SERVER_ERROR,
         };
 
         (status, Json(self)).into_response()
@@ -388,5 +393,12 @@ impl From<hiqlite_wal::error::Error> for Error {
     fn from(value: hiqlite_wal::error::Error) -> Self {
         trace!("hiqlite_wal::error::Error: {value}");
         Self::WAL(value.to_string())
+    }
+}
+
+#[cfg(feature = "toml")]
+impl From<std::string::String> for Error {
+    fn from(err: std::string::String) -> Self {
+        Error::String(err.into())
     }
 }

--- a/hiqlite/src/store/state_machine/memory/state_machine.rs
+++ b/hiqlite/src/store/state_machine/memory/state_machine.rs
@@ -259,7 +259,9 @@ impl StateMachineMemory {
             // because otherwise there would be a gap in logs
             let _ = fs::remove_dir_all(&path_snapshots).await;
         }
-        fs::create_dir_all(&path_snapshots).await?;
+        fs::create_dir_all(&path_snapshots).await.map_err(|err| {
+            Error::String(format!("Cannot create directory '{path_snapshots}': {err}"))
+        })?;
         set_path_access(&path_sm, 0o700)
             .await
             .expect("Cannot set access rights for path_sm");


### PR DESCRIPTION
Recently I could not start hiqlite in cache only mode and just received an OS error "not writable". The reason was that even in cache only mode `data_dir` must exist and be writable.

This pull request adds some error message to the fact and some documentation line to the top level file `hiqlite.toml`.