### PR TITLE
fix: cookie header format for secure cookies

### DIFF
--- a/hiqlite/src/dashboard/session.rs
+++ b/hiqlite/src/dashboard/session.rs
@@ -76,7 +76,7 @@ impl Session {
         let cookie_header = if *INSECURE_COOKIES {
             format!("{COOKIE_NAME_DEV}={b64}; HttpOnly; SameSite=Lax; Max-Age={max_age}")
         } else {
-            format!("{COOKIE_NAME}={b64}; Secure; HttpOnly; SameSite=Lax; Max-Age={max_age} Path=/")
+            format!("{COOKIE_NAME}={b64}; Secure; HttpOnly; SameSite=Lax; Max-Age={max_age}; Path=/")
         };
 
         Ok(cookie_header)


### PR DESCRIPTION
Fixed the `Path` attribute for session cookies. Cookies with the `__Host-` prefix must include `Path=/` per the [Cookie Prefixes spec](https://datatracker.ietf.org/doc/html/draft-west-cookie-prefixes-05#section-3.2).