### PR TITLE
Release 0.14.0-202606024: bump rusqlite 0.40, fs4 1.1, tikv-jemallocator 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ reqwest = { version = "0.13", default-features = false, features = [
     "json",
     "rustls-no-provider",
 ] }
-rusqlite = { version = "0.39", features = [
+rusqlite = { version = "0.40", features = [
     "backup",
     "bundled",
     "cache",
@@ -95,7 +95,7 @@ rustls = { version = "0.23.37", default-features = false, features = [
 ] }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.57"
-serde_rusqlite = "0.42"
+serde_rusqlite = "0.43"
 sha2 = { version = "0.11", features = [] }
 spow = { version = "0.6", features = ["server"] }
 thiserror = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ fastwebsockets = { version = "0.10.0", features = [
     "unstable-split",
 ] }
 flume = "0.12"
-fs4 = { version = "0.13.1", features = ["sync"] }
+fs4 = { version = "1.1.0", features = ["sync"] }
 futures-util = "0.3.30"
 getrandom = { version = "0.4", features = ["std"] }
 hex = "0.4.3"
@@ -100,7 +100,7 @@ sha2 = { version = "0.11", features = [] }
 spow = { version = "0.6", features = ["server"] }
 thiserror = "2"
 thread-priority = "3.0.0"
-tikv-jemallocator = "0.6.0"
+tikv-jemallocator = "0.7.0"
 time = "0.3.47"
 tokio = { version = "1.43.1", features = ["fs", "sync", "rt-multi-thread"] }
 tokio-rustls = { version = "0.26.4", features = ["ring"] }

--- a/examples/bench/Cargo.lock
+++ b/examples/bench/Cargo.lock
@@ -1409,7 +1409,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hiqlite"
-version = "0.13.2"
+version = "0.14.0-202606024"
 dependencies = [
  "axum",
  "axum-server",
@@ -3490,9 +3490,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
 dependencies = [
  "cc",
  "libc",
@@ -3500,9 +3500,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",

--- a/examples/bench/Cargo.lock
+++ b/examples/bench/Cargo.lock
@@ -352,7 +352,7 @@ dependencies = [
  "rustls 0.23.37",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.4",
  "tower-service",
 ]
 
@@ -1409,10 +1409,8 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hiqlite"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
- "aws-lc-rs",
- "aws-lc-sys",
  "axum",
  "axum-server",
  "bincode",
@@ -1440,11 +1438,11 @@ dependencies = [
  "openraft",
  "rcgen",
  "reqwest",
- "rkyv",
  "rusqlite",
  "rust-embed",
  "rust_decimal",
  "rustls 0.23.37",
+ "rustls-webpki 0.103.13",
  "serde",
  "serde_json",
  "serde_rusqlite",
@@ -1454,7 +1452,7 @@ dependencies = [
  "tikv-jemallocator",
  "time",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.4",
  "toml",
  "tower-layer",
  "tower-service",
@@ -1466,6 +1464,8 @@ dependencies = [
 [[package]]
 name = "hiqlite-derive"
 version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4edb6e4dbbb5f8e407335b3a55ea5ab79bd7c647ccffb09617d2b606d7f517b6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1475,6 +1475,8 @@ dependencies = [
 [[package]]
 name = "hiqlite-wal"
 version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d53e55d82308a8433aab0cbbd8ba981e8e4fbecfa62b407ef26e92a671a65e"
 dependencies = [
  "bincode",
  "byteorder",
@@ -1664,7 +1666,7 @@ dependencies = [
  "rustls 0.23.37",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.4",
  "tower-service",
 ]
 
@@ -2010,9 +2012,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+checksum = "a76001fb4daed01e5f2b518aac0b4dc592e7c734da63dbffcf0c64fa612a8d0c"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2742,7 +2744,7 @@ dependencies = [
  "serde_json",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
  "tower-http",
@@ -2809,9 +2811,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+checksum = "1b3492ea85308705c3a5cc24fb9b9cf77273d30590349070db42991202b214c4"
 dependencies = [
  "bitflags",
  "chrono",
@@ -2934,7 +2936,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -2996,7 +2998,7 @@ dependencies = [
  "rustls 0.23.37",
  "rustls-native-certs 0.8.3",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
@@ -3021,9 +3023,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3065,7 +3067,7 @@ dependencies = [
  "quinn",
  "quinn-proto",
  "reqwest",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "serde",
  "sha2 0.10.9",
  "thiserror 2.0.18",
@@ -3211,9 +3213,9 @@ dependencies = [
 
 [[package]]
 name = "serde_rusqlite"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee252eeacd2dc6d0dcbc7b3e5a17f4c1bae19e811e843a9c7698f849b1611d67"
+checksum = "44f51ff08953caf83bbd0d9be7ee58d41f1d1adc19a2e84c43f83ca50258571e"
 dependencies = [
  "rusqlite",
  "serde_core",
@@ -3611,12 +3613,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.0"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls 0.23.37",
- "rustls-pki-types",
  "tokio",
 ]
 

--- a/examples/cache-only/Cargo.lock
+++ b/examples/cache-only/Cargo.lock
@@ -1270,10 +1270,8 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hiqlite"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
- "aws-lc-rs",
- "aws-lc-sys",
  "axum",
  "axum-server",
  "bincode",
@@ -1296,10 +1294,10 @@ dependencies = [
  "openraft",
  "rcgen",
  "reqwest",
- "rkyv",
  "rust-embed",
  "rust_decimal",
  "rustls",
+ "rustls-webpki",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -1319,6 +1317,8 @@ dependencies = [
 [[package]]
 name = "hiqlite-derive"
 version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4edb6e4dbbb5f8e407335b3a55ea5ab79bd7c647ccffb09617d2b606d7f517b6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1328,6 +1328,8 @@ dependencies = [
 [[package]]
 name = "hiqlite-wal"
 version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d53e55d82308a8433aab0cbbd8ba981e8e4fbecfa62b407ef26e92a671a65e"
 dependencies = [
  "bincode",
  "byteorder",
@@ -2612,7 +2614,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3118,9 +3120,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",

--- a/examples/cache-only/Cargo.lock
+++ b/examples/cache-only/Cargo.lock
@@ -1270,7 +1270,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hiqlite"
-version = "0.13.2"
+version = "0.14.0-202606024"
 dependencies = [
  "axum",
  "axum-server",

--- a/examples/sqlite-only/Cargo.lock
+++ b/examples/sqlite-only/Cargo.lock
@@ -1350,10 +1350,8 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hiqlite"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
- "aws-lc-rs",
- "aws-lc-sys",
  "axum",
  "axum-server",
  "bincode",
@@ -1379,11 +1377,11 @@ dependencies = [
  "openraft",
  "rcgen",
  "reqwest",
- "rkyv",
  "rusqlite",
  "rust-embed",
  "rust_decimal",
  "rustls",
+ "rustls-webpki",
  "serde",
  "serde_json",
  "serde_rusqlite",
@@ -1404,6 +1402,8 @@ dependencies = [
 [[package]]
 name = "hiqlite-derive"
 version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4edb6e4dbbb5f8e407335b3a55ea5ab79bd7c647ccffb09617d2b606d7f517b6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1413,6 +1413,8 @@ dependencies = [
 [[package]]
 name = "hiqlite-wal"
 version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d53e55d82308a8433aab0cbbd8ba981e8e4fbecfa62b407ef26e92a671a65e"
 dependencies = [
  "bincode",
  "byteorder",
@@ -1874,9 +1876,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+checksum = "a76001fb4daed01e5f2b518aac0b4dc592e7c734da63dbffcf0c64fa612a8d0c"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2667,9 +2669,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+checksum = "1b3492ea85308705c3a5cc24fb9b9cf77273d30590349070db42991202b214c4"
 dependencies = [
  "bitflags",
  "chrono",
@@ -2825,7 +2827,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3003,9 +3005,9 @@ dependencies = [
 
 [[package]]
 name = "serde_rusqlite"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee252eeacd2dc6d0dcbc7b3e5a17f4c1bae19e811e843a9c7698f849b1611d67"
+checksum = "44f51ff08953caf83bbd0d9be7ee58d41f1d1adc19a2e84c43f83ca50258571e"
 dependencies = [
  "rusqlite",
  "serde_core",
@@ -3364,12 +3366,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.0"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
- "rustls-pki-types",
  "tokio",
 ]
 

--- a/examples/sqlite-only/Cargo.lock
+++ b/examples/sqlite-only/Cargo.lock
@@ -1350,7 +1350,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hiqlite"
-version = "0.13.2"
+version = "0.14.0-202606024"
 dependencies = [
  "axum",
  "axum-server",

--- a/examples/walkthrough/Cargo.lock
+++ b/examples/walkthrough/Cargo.lock
@@ -1405,10 +1405,8 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hiqlite"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
- "aws-lc-rs",
- "aws-lc-sys",
  "axum",
  "axum-server",
  "bincode",
@@ -1436,11 +1434,11 @@ dependencies = [
  "openraft",
  "rcgen",
  "reqwest",
- "rkyv",
  "rusqlite",
  "rust-embed",
  "rust_decimal",
  "rustls 0.23.37",
+ "rustls-webpki 0.103.13",
  "serde",
  "serde_json",
  "serde_rusqlite",
@@ -1461,6 +1459,8 @@ dependencies = [
 [[package]]
 name = "hiqlite-derive"
 version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4edb6e4dbbb5f8e407335b3a55ea5ab79bd7c647ccffb09617d2b606d7f517b6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1470,6 +1470,8 @@ dependencies = [
 [[package]]
 name = "hiqlite-wal"
 version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d53e55d82308a8433aab0cbbd8ba981e8e4fbecfa62b407ef26e92a671a65e"
 dependencies = [
  "bincode",
  "byteorder",
@@ -1967,9 +1969,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+checksum = "a76001fb4daed01e5f2b518aac0b4dc592e7c734da63dbffcf0c64fa612a8d0c"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2774,9 +2776,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+checksum = "1b3492ea85308705c3a5cc24fb9b9cf77273d30590349070db42991202b214c4"
 dependencies = [
  "bitflags",
  "chrono",
@@ -2893,7 +2895,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -2955,7 +2957,7 @@ dependencies = [
  "rustls 0.23.37",
  "rustls-native-certs 0.8.3",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
@@ -2980,9 +2982,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3024,7 +3026,7 @@ dependencies = [
  "quinn",
  "quinn-proto",
  "reqwest",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "serde",
  "sha2 0.10.9",
  "thiserror 2.0.18",
@@ -3184,9 +3186,9 @@ dependencies = [
 
 [[package]]
 name = "serde_rusqlite"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee252eeacd2dc6d0dcbc7b3e5a17f4c1bae19e811e843a9c7698f849b1611d67"
+checksum = "44f51ff08953caf83bbd0d9be7ee58d41f1d1adc19a2e84c43f83ca50258571e"
 dependencies = [
  "rusqlite",
  "serde_core",

--- a/examples/walkthrough/Cargo.lock
+++ b/examples/walkthrough/Cargo.lock
@@ -1405,7 +1405,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hiqlite"
-version = "0.13.2"
+version = "0.14.0-202606024"
 dependencies = [
  "axum",
  "axum-server",

--- a/hiqlite-derive/Cargo.toml
+++ b/hiqlite-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hiqlite-derive"
-version = "0.13.0"
+version = "0.14.0-202606024"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/hiqlite-wal/Cargo.toml
+++ b/hiqlite-wal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hiqlite-wal"
-version = "0.13.0"
+version = "0.14.0-202606024"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/hiqlite-wal/src/lockfile.rs
+++ b/hiqlite-wal/src/lockfile.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use fs4::fs_std::FileExt;
+use fs4::FileExt;
 use std::fs::{self, File, OpenOptions};
 
 #[derive(Debug)]
@@ -41,12 +41,12 @@ impl LockFile {
     }
 
     fn lock_file(file: &File) -> Result<(), Error> {
-        match file.try_lock_exclusive() {
-            Ok(true) => Ok(()),
-            Ok(false) => Err(Error::Internal(
+        match FileExt::try_lock(file) {
+            Ok(()) => Ok(()),
+            Err(fs4::TryLockError::WouldBlock) => Err(Error::Internal(
                 "WAL lock file is in use by another process".into(),
             )),
-            Err(err) => Err(Error::Internal(
+            Err(fs4::TryLockError::Error(err)) => Err(Error::Internal(
                 format!("Error locking WAL lock file: {err}").into(),
             )),
         }

--- a/hiqlite/Cargo.toml
+++ b/hiqlite/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.13.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
-rust-version = "1.88.0"
+# Bumped to 1.95 by serde_rusqlite 0.43 (required for rusqlite 0.40), which depends on serde_core.
+rust-version = "1.95.0"
 categories = ["database", "caching"]
 keywords = ["database", "sql", "sqlite", "raft", "cache"]
 description = "Hiqlite - highly-available, embeddable, raft-based SQLite + cache"

--- a/hiqlite/Cargo.toml
+++ b/hiqlite/Cargo.toml
@@ -1,10 +1,9 @@
 [package]
 name = "hiqlite"
-version = "0.13.2"
+version = "0.14.0-202606024"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
-# Bumped to 1.95 by serde_rusqlite 0.43 (required for rusqlite 0.40), which depends on serde_core.
 rust-version = "1.95.0"
 categories = ["database", "caching"]
 keywords = ["database", "sql", "sqlite", "raft", "cache"]


### PR DESCRIPTION
Bumps the SQLite stack and other lagging dependencies, and cuts the breaking `0.14.0-202606024` release. Updated per @sebadob's review.

## Dependency bumps (workspace)

| crate | before | after | notes |
|---|---|---|---|
| rusqlite | 0.39 | 0.40 | pulls libsqlite3-sys 0.37 -> 0.38 |
| serde_rusqlite | 0.42 | 0.43 | lockstep with rusqlite; pulls serde_core |
| fs4 | 0.13.1 | 1.1.0 | API change, see below |
| tikv-jemallocator | 0.6.0 | 0.7.0 | drop-in |

## Versions

All three crates bumped to `0.14.0-202606024` (breaking change). MSRV is `1.95` (raised by serde_rusqlite 0.43, which pulls serde_core). The inter-crate dependency requirements are left at "0.13" since 0.14 is unpublished; assuming they bump at publish time per the justfile flow.

## fs4 1.x change

fs4 1.x mirrors std's now-stable file locking (Rust 1.89):

* `fs4::fs_std::FileExt` becomes `fs4::FileExt` (trait moved to crate root)
* `try_lock_exclusive` becomes `try_lock`, returning `Result<(), TryLockError>` instead of `Result<bool>`

On MSRV 1.95, std's inherent `File::try_lock` shadows the trait method, so `hiqlite-wal/src/lockfile.rs` calls fs4 explicitly via `FileExt::try_lock(...)`. Since std now covers this natively, fs4 could alternatively be dropped here entirely; flagged on the thread for your call.

## Notes

* No `cargo fmt --check`: the tree is not default-rustfmt-clean, so a gate would fail until a one-time reformat.
* No source changes for rusqlite 0.40: hiqlite implements no custom VTabs (the 0.40 breaking changes are all in the VTab API), and every enabled feature still exists in 0.40.

## Validation (Rust 1.95)

* `cargo clippy -- -D warnings` (workspace) clean.
* `cargo check -p hiqlite --features full,jemalloc` clean.
* `hiqlite-wal` clippy clean with the fs4 fix.
* All example crates build; lockfiles regenerated.
