### PR TITLE
Fix: check for left-over config vars from disabled features

### DIFF
--- a/hiqlite/src/config_toml.rs
+++ b/hiqlite/src/config_toml.rs
@@ -328,9 +328,40 @@ fn check_empty(table: toml::Table, tbl_name: &str) -> Result<(), Error> {
     if table.is_empty() {
         Ok(())
     } else {
-        Err(Error::Config(
-            format!("Unknown Config data in section: '{tbl_name}': {table:?}").into(),
-        ))
+        // It may be the case that we found values that belong to not-activated features.
+        // We should not error on these.
+        let mut err = false;
+        for key in table.keys() {
+            if ![
+                "backup_cron",
+                "backup_keep_days",
+                "backup_keep_days_local",
+                "cache_storage_disk",
+                "s3_url",
+                "s3_bucket",
+                "s3_region",
+                "s3_path_style",
+                "s3_key",
+                "s3_secret",
+                "password_dashboard",
+                "insecure_cookie",
+                "enc_key_active",
+                "enc_keys",
+            ]
+            .contains(&key.as_str())
+            {
+                err = true;
+                break;
+            }
+        }
+
+        if err {
+            Err(Error::Config(
+                format!("Unknown Config data in section: '{tbl_name}': {table:?}").into(),
+            ))
+        } else {
+            Ok(())
+        }
     }
 }
 

--- a/justfile
+++ b/justfile
@@ -125,9 +125,7 @@ test test="":
     set -euxo pipefail
     clear
     # we need to run the tests with nightly to not get an error for docs auto cfg
-    RUSTFLAGS="--cfg tokio_unstable" cargo +nightly test \
-        --features cache,counters,dlock,listen_notify,macros,toml \
-        {{ test }}
+    cargo test --features cache,counters,dlock,listen_notify,macros,toml {{ test }}
 
 # builds the code
 build ty="server":


### PR DESCRIPTION
Check for left-over config vars from disabled features and remove nightly requirement from tests.