### PR TITLE
Don't require data_dir for in-memory cache-only nodes

### DIFF
--- a/hiqlite.toml
+++ b/hiqlite.toml
@@ -41,6 +41,10 @@ listen_addr_api = "0.0.0.0"
 listen_addr_raft = "0.0.0.0"
 
 # The data dir hiqlite will store raft logs and state machine data in.
+# It must exist and be writable, unless you run a pure cache-only node (no
+# SQLite) with `cache_storage_disk = false`: that mode keeps everything
+# in-memory and never touches `data_dir`.
+# See also `cache_storage_disk`.
 #
 # default: data
 # overwritten by: HQL_DATA_DIR
@@ -141,6 +145,9 @@ wal_size = 2097152
 # all your cached data will be gone.
 # In-memory only hugegly increases the throughput though, so it
 # depends on your needs, what you should prefer.
+# In a pure cache-only deployment (no SQLite), `false` also means `data_dir`
+# is never used and does not need to exist.
+# See also `data_dir`.
 #
 # default: true
 # overwritten by: HQL_CACHE_STORAGE_DISK

--- a/hiqlite.toml
+++ b/hiqlite.toml
@@ -41,8 +41,9 @@ listen_addr_api = "0.0.0.0"
 listen_addr_raft = "0.0.0.0"
 
 # The data dir hiqlite will store raft logs and state machine data in.
-# It must exist and be writable, unless you run a pure cache-only node (no
-# SQLite) with `cache_storage_disk = false`: that mode keeps everything
+# It must exist and be writable, unless hiqlite was built with the
+# `in-memory-snapshots` feature and runs a pure cache-only node (no SQLite)
+# with `cache_storage_disk = false`: that combination keeps everything
 # in-memory and never touches `data_dir`.
 # See also `cache_storage_disk`.
 #
@@ -145,8 +146,10 @@ wal_size = 2097152
 # all your cached data will be gone.
 # In-memory only hugegly increases the throughput though, so it
 # depends on your needs, what you should prefer.
-# In a pure cache-only deployment (no SQLite), `false` also means `data_dir`
-# is never used and does not need to exist.
+# With the `in-memory-snapshots` build feature, a pure cache-only deployment
+# (no SQLite) using `false` also keeps Snapshots in-memory, so `data_dir` is
+# never used and does not need to exist. Without that feature, Snapshots are
+# always written to `data_dir`.
 # See also `data_dir`.
 #
 # default: true

--- a/hiqlite/Cargo.toml
+++ b/hiqlite/Cargo.toml
@@ -37,6 +37,10 @@ dashboard = [
 dlock = ["cache"]
 cast_ints = []
 cast_ints_unchecked = []
+# Opt-in: keep Cache Snapshots in-memory instead of on disk. This lets a pure
+# cache-only node run without a `data_dir`, but doubles snapshot memory cost and
+# disables zero-copy snapshot streaming from file. Deliberately NOT part of `full`.
+in-memory-snapshots = ["cache"]
 full = [
     "auto-heal",
     "backup",

--- a/hiqlite/src/config.rs
+++ b/hiqlite/src/config.rs
@@ -29,7 +29,10 @@ pub struct NodeConfig {
     pub listen_addr_api: Cow<'static, str>,
     /// Listen address for the Raft Server
     pub listen_addr_raft: Cow<'static, str>,
-    /// The directory where the replication log, database and snapshots should be stored
+    /// The directory where the replication log, database and snapshots should be stored.
+    /// It must exist and be writable, unless you run a pure cache-only node (no SQLite)
+    /// with `cache_storage_disk = false`: that mode keeps everything in-memory and never
+    /// touches `data_dir`.
     pub data_dir: Cow<'static, str>,
     /// If the SQLite should be written to disk, provide a filename here.
     /// It is recommended to leave it set to None if your DB size fits fully into memory, and
@@ -68,6 +71,10 @@ pub struct NodeConfig {
     ///
     /// Keep in mind that the in-memory WAL storage is roughly 4 times faster than the one on disk,
     /// even with memory mapped WAL files (depending on your disk of course).
+    ///
+    /// In a pure cache-only deployment (no SQLite), `false` additionally means that `data_dir`
+    /// is never used and does not need to exist, because Cache WAL + Snapshots are kept fully
+    /// in-memory.
     ///
     /// CAUTION: There is a known bug in the Raft that can lead to a Raft cluster lock up after
     /// a pure in-memory member (value set to `false`) crashes or is being force-killed, before it

--- a/hiqlite/src/config.rs
+++ b/hiqlite/src/config.rs
@@ -30,9 +30,9 @@ pub struct NodeConfig {
     /// Listen address for the Raft Server
     pub listen_addr_raft: Cow<'static, str>,
     /// The directory where the replication log, database and snapshots should be stored.
-    /// It must exist and be writable, unless you run a pure cache-only node (no SQLite)
-    /// with `cache_storage_disk = false`: that mode keeps everything in-memory and never
-    /// touches `data_dir`.
+    /// It must exist and be writable, unless you build with the `in-memory-snapshots`
+    /// feature and run a pure cache-only node (no SQLite) with `cache_storage_disk = false`:
+    /// that combination keeps everything in-memory and never touches `data_dir`.
     pub data_dir: Cow<'static, str>,
     /// If the SQLite should be written to disk, provide a filename here.
     /// It is recommended to leave it set to None if your DB size fits fully into memory, and
@@ -72,9 +72,10 @@ pub struct NodeConfig {
     /// Keep in mind that the in-memory WAL storage is roughly 4 times faster than the one on disk,
     /// even with memory mapped WAL files (depending on your disk of course).
     ///
-    /// In a pure cache-only deployment (no SQLite), `false` additionally means that `data_dir`
-    /// is never used and does not need to exist, because Cache WAL + Snapshots are kept fully
-    /// in-memory.
+    /// With the opt-in `in-memory-snapshots` feature, a pure cache-only deployment (no SQLite)
+    /// using `false` additionally keeps Cache Snapshots in-memory, so `data_dir` is never used
+    /// and does not need to exist. Without that feature, Snapshots are still written to
+    /// `data_dir` (the default), which streams them efficiently but requires the directory.
     ///
     /// CAUTION: There is a known bug in the Raft that can lead to a Raft cluster lock up after
     /// a pure in-memory member (value set to `false`) crashes or is being force-killed, before it

--- a/hiqlite/src/store/state_machine/memory/mod.rs
+++ b/hiqlite/src/store/state_machine/memory/mod.rs
@@ -17,5 +17,5 @@ openraft::declare_raft_types!(
         D = CacheRequest,
         R = CacheResponse,
         Node = Node,
-        SnapshotData = tokio::fs::File,
+        SnapshotData = Cursor<Vec<u8>>,
 );

--- a/hiqlite/src/store/state_machine/memory/mod.rs
+++ b/hiqlite/src/store/state_machine/memory/mod.rs
@@ -1,5 +1,6 @@
 use crate::store::state_machine::memory::state_machine::{CacheRequest, CacheResponse};
 use crate::Node;
+#[cfg(feature = "in-memory-snapshots")]
 use std::io::Cursor;
 
 mod cache_ttl_handler;
@@ -12,6 +13,19 @@ pub mod dlock_handler;
 #[cfg(feature = "listen_notify_local")]
 pub mod notify_handler;
 
+// By default Cache Snapshots are streamed directly from file, which is zero-copy and
+// efficient even for large caches. With the opt-in `in-memory-snapshots` feature the
+// snapshot is held in memory instead, so a pure cache-only node needs no `data_dir`.
+#[cfg(not(feature = "in-memory-snapshots"))]
+openraft::declare_raft_types!(
+    pub TypeConfigKV:
+        D = CacheRequest,
+        R = CacheResponse,
+        Node = Node,
+        SnapshotData = tokio::fs::File,
+);
+
+#[cfg(feature = "in-memory-snapshots")]
 openraft::declare_raft_types!(
     pub TypeConfigKV:
         D = CacheRequest,

--- a/hiqlite/src/store/state_machine/memory/state_machine.rs
+++ b/hiqlite/src/store/state_machine/memory/state_machine.rs
@@ -25,7 +25,7 @@ use tokio::fs;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{Mutex, RwLock, oneshot};
 use tokio::task;
-use tracing::{debug, info, warn};
+use tracing::warn;
 use uuid::Uuid;
 
 #[cfg(feature = "dlock")]
@@ -34,7 +34,7 @@ use crate::store::state_machine::memory::dlock_handler::{self, *};
 use crate::store::state_machine::memory::notify_handler::{self, NotifyRequest};
 
 type Entry = openraft::Entry<TypeConfigKV>;
-type SnapshotData = fs::File;
+type SnapshotData = Cursor<Vec<u8>>;
 
 type SnapshotKVs = Vec<(BTreeMap<String, Vec<u8>>, BTreeMap<String, i64>)>;
 type SnapshotTTLs = Vec<BTreeMap<i64, String>>;
@@ -45,6 +45,8 @@ type SnapshotDataContent = (
     SnapshotTTLs,
     SnapshotLocks,
 );
+/// The latest snapshot kept in memory (`meta` + serialized bytes) for memory-only mode.
+type MemSnapshot = (SnapshotMeta<NodeId, Node>, Vec<u8>);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum CacheRequest {
@@ -127,6 +129,10 @@ pub struct StateMachineMemory {
     data: RwLock<StateMachineData>,
     path_snapshots: String,
     in_memory_only: bool,
+    /// Holds the latest snapshot when running purely in-memory (`in_memory_only == true`).
+    /// In that mode nothing is ever written to `data_dir`, so a cache-only node does not
+    /// require it to exist or be writable. Unused (always `None`) when persisting to disk.
+    snapshot_mem: RwLock<Option<MemSnapshot>>,
 
     pub(crate) tx_caches: Vec<flume::Sender<CacheRequestHandler>>,
     tx_ttls: Vec<flume::Sender<TtlRequest>>,
@@ -204,6 +210,16 @@ impl RaftSnapshotBuilder<TypeConfigKV> for Arc<StateMachineMemory> {
             (meta, snapshot_bytes)
         };
 
+        // In memory-only mode we keep the snapshot in memory and never touch `data_dir`,
+        // so a pure cache-only node does not require it to exist or be writable.
+        if self.in_memory_only {
+            *self.snapshot_mem.write().await = Some((meta.clone(), snapshot_bytes.clone()));
+            return Ok(Snapshot {
+                meta,
+                snapshot: Box::new(Cursor::new(snapshot_bytes)),
+            });
+        }
+
         let path = format!("{}/{}", self.path_snapshots, meta.snapshot_id);
         let path_temp = format!("{path}.temp");
         {
@@ -218,9 +234,6 @@ impl RaftSnapshotBuilder<TypeConfigKV> for Arc<StateMachineMemory> {
         fs::copy(&path_temp, &path)
             .await
             .map_err(|err| StorageIOError::write_state_machine(&err))?;
-        let file = fs::File::open(&path)
-            .await
-            .map_err(|err| StorageIOError::read_state_machine(&err))?;
 
         // cleanup task for old snapshots
         let id = meta.snapshot_id.clone();
@@ -236,12 +249,10 @@ impl RaftSnapshotBuilder<TypeConfigKV> for Arc<StateMachineMemory> {
             }
         });
 
-        let snapshot = Snapshot {
+        Ok(Snapshot {
             meta,
-            snapshot: Box::new(file),
-        };
-
-        Ok(snapshot)
+            snapshot: Box::new(Cursor::new(snapshot_bytes)),
+        })
     }
 }
 
@@ -253,15 +264,15 @@ impl StateMachineMemory {
         let path_sm = format!("{base_path}/state_machine_cache");
         let path_snapshots = format!("{path_sm}/snapshots");
 
-        if in_memory_only {
-            // in this case we must always start clean,
-            // because otherwise there would be a gap in logs
-            let _ = fs::remove_dir_all(&path_snapshots).await;
+        // In memory-only mode we never persist snapshots, so we must not touch `data_dir`
+        // at all: it does not need to exist for a pure cache-only node. When persisting to
+        // disk we create (and keep) the snapshot dir so existing snapshots survive a restart.
+        if !in_memory_only {
+            fs::create_dir_all(&path_snapshots).await?;
+            set_path_access(&path_sm, 0o700)
+                .await
+                .expect("Cannot set access rights for path_sm");
         }
-        fs::create_dir_all(&path_snapshots).await?;
-        set_path_access(&path_sm, 0o700)
-            .await
-            .expect("Cannot set access rights for path_sm");
 
         // we will start a separate task for each given cache index
         let variants = C::hiqlite_cache_variants();
@@ -283,6 +294,7 @@ impl StateMachineMemory {
             data: RwLock::new(StateMachineData::default()),
             path_snapshots,
             in_memory_only,
+            snapshot_mem: RwLock::new(None),
             tx_caches,
             tx_ttls,
             #[cfg(feature = "listen_notify_local")]
@@ -293,10 +305,13 @@ impl StateMachineMemory {
             tx_dlock,
         };
 
-        if let Some((_, content)) = slf
-            .read_current_snapshot()
-            .await
-            .expect("Cannot read current snapshot")
+        // Only disk-backed snapshots can be restored on startup. In memory-only mode the
+        // snapshot lives in `snapshot_mem` and starts empty, so there is nothing to read.
+        if !in_memory_only
+            && let Some((_, content)) = slf
+                .read_current_snapshot()
+                .await
+                .expect("Cannot read current snapshot")
         {
             slf.update_state_machine(content).await;
         }
@@ -678,19 +693,12 @@ impl RaftStateMachine<TypeConfigKV> for Arc<StateMachineMemory> {
     }
 
     #[tracing::instrument(skip_all)]
-    async fn begin_receiving_snapshot(&mut self) -> Result<Box<fs::File>, StorageError<NodeId>> {
-        let path = format!("{}/temp", self.path_snapshots);
-        info!("Saving incoming snapshot to {}", path);
-
-        // clean up possible existing old data
-        let _ = fs::remove_file(&path).await;
-
-        match fs::File::create(path).await {
-            Ok(file) => Ok(Box::new(file)),
-            Err(err) => Err(StorageError::IO {
-                source: StorageIOError::write(&err),
-            }),
-        }
+    async fn begin_receiving_snapshot(
+        &mut self,
+    ) -> Result<Box<SnapshotData>, StorageError<NodeId>> {
+        // The incoming snapshot is streamed into memory. For disk-backed nodes it is
+        // persisted in `install_snapshot`; for memory-only nodes it never hits disk.
+        Ok(Box::new(Cursor::new(Vec::new())))
     }
 
     #[tracing::instrument(skip_all)]
@@ -699,21 +707,18 @@ impl RaftStateMachine<TypeConfigKV> for Arc<StateMachineMemory> {
         meta: &SnapshotMeta<NodeId, Node>,
         snapshot: Box<SnapshotData>,
     ) -> Result<(), StorageError<NodeId>> {
-        let src = format!("{}/temp", self.path_snapshots);
-        let dest = format!("{}/{}", self.path_snapshots, meta.snapshot_id);
-        fs::copy(&src, &dest)
-            .await
-            .map_err(|err| StorageError::IO {
-                source: StorageIOError::write(&err),
-            })?;
+        let bytes = (*snapshot).into_inner();
 
-        fs::remove_file(src).await.map_err(|err| StorageError::IO {
-            source: StorageIOError::write(&err),
-        })?;
-
-        let bytes = fs::read(dest)
-            .await
-            .map_err(|e| StorageIOError::read_snapshot(Some(meta.signature()), &e))?;
+        if self.in_memory_only {
+            *self.snapshot_mem.write().await = Some((meta.clone(), bytes.clone()));
+        } else {
+            let dest = format!("{}/{}", self.path_snapshots, meta.snapshot_id);
+            fs::write(&dest, &bytes)
+                .await
+                .map_err(|err| StorageError::IO {
+                    source: StorageIOError::write(&err),
+                })?;
+        }
 
         let (meta_snap, kvs, ttls, locks) = deserialize::<SnapshotDataContent>(&bytes)
             .map_err(|e| StorageIOError::read_snapshot(Some(meta.signature()), &e))?;
@@ -730,20 +735,92 @@ impl RaftStateMachine<TypeConfigKV> for Arc<StateMachineMemory> {
     async fn get_current_snapshot(
         &mut self,
     ) -> Result<Option<Snapshot<TypeConfigKV>>, StorageError<NodeId>> {
+        if self.in_memory_only {
+            let guard = self.snapshot_mem.read().await;
+            return Ok(guard.as_ref().map(|(meta, bytes)| Snapshot {
+                meta: meta.clone(),
+                snapshot: Box::new(Cursor::new(bytes.clone())),
+            }));
+        }
+
         match self.read_current_snapshot().await? {
             None => Ok(None),
-            Some((path, (meta, kvs, ttls, locks))) => {
-                let file = fs::File::open(path).await.map_err(|err| StorageError::IO {
+            Some((path, (meta, ..))) => {
+                let bytes = fs::read(&path).await.map_err(|err| StorageError::IO {
                     source: StorageIOError::read(&err),
                 })?;
 
                 let snapshot = Snapshot {
                     meta,
-                    snapshot: Box::new(file),
+                    snapshot: Box::new(Cursor::new(bytes)),
                 };
 
                 Ok(Some(snapshot))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::CacheVariants;
+    use openraft::RaftSnapshotBuilder;
+    use openraft::storage::RaftStateMachine;
+    use std::sync::Arc;
+
+    #[derive(Debug)]
+    enum TestCache {
+        One,
+    }
+
+    impl CacheVariants for TestCache {
+        fn hiqlite_cache_index(&self) -> usize {
+            0
+        }
+
+        fn hiqlite_cache_variants() -> &'static [(usize, &'static str)] {
+            &[(0, "One")]
+        }
+    }
+
+    /// A pure cache-only node running in-memory (`cache_storage_disk = false`) must never
+    /// touch `data_dir`: it does not need to exist or be writable. Snapshots are kept in
+    /// memory and are still retrievable for the Raft to stream to other members.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn in_memory_only_does_not_require_data_dir() {
+        let base_dir = std::env::temp_dir().join("hiqlite_inmem_only_no_datadir_test");
+        // make sure the path does not exist up-front
+        let _ = std::fs::remove_dir_all(&base_dir);
+        let base = base_dir.to_str().unwrap();
+
+        let mut sm = Arc::new(
+            StateMachineMemory::new::<TestCache>(base, true)
+                .await
+                .expect("in-memory state machine to start without a data_dir"),
+        );
+
+        // nothing may be created on disk in memory-only mode
+        assert!(
+            !base_dir.exists(),
+            "memory-only mode must not create the data_dir"
+        );
+
+        // building a snapshot keeps it in memory and still must not write to disk
+        let built = sm.build_snapshot().await.expect("snapshot build to succeed");
+        assert!(
+            !base_dir.exists(),
+            "building a snapshot must not create the data_dir in memory-only mode"
+        );
+
+        // the in-memory snapshot is retrievable (what the Raft streams to other members)
+        let current = sm
+            .get_current_snapshot()
+            .await
+            .expect("get_current_snapshot to succeed")
+            .expect("an in-memory snapshot to be present after building one");
+        assert_eq!(current.meta.snapshot_id, built.meta.snapshot_id);
+
+        let _ = std::fs::remove_dir_all(&base_dir);
     }
 }

--- a/hiqlite/src/store/state_machine/memory/state_machine.rs
+++ b/hiqlite/src/store/state_machine/memory/state_machine.rs
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
+#[cfg(feature = "in-memory-snapshots")]
 use std::io::Cursor;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -25,6 +26,8 @@ use tokio::fs;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{Mutex, RwLock, oneshot};
 use tokio::task;
+#[cfg(not(feature = "in-memory-snapshots"))]
+use tracing::info;
 use tracing::warn;
 use uuid::Uuid;
 
@@ -34,6 +37,9 @@ use crate::store::state_machine::memory::dlock_handler::{self, *};
 use crate::store::state_machine::memory::notify_handler::{self, NotifyRequest};
 
 type Entry = openraft::Entry<TypeConfigKV>;
+#[cfg(not(feature = "in-memory-snapshots"))]
+type SnapshotData = fs::File;
+#[cfg(feature = "in-memory-snapshots")]
 type SnapshotData = Cursor<Vec<u8>>;
 
 type SnapshotKVs = Vec<(BTreeMap<String, Vec<u8>>, BTreeMap<String, i64>)>;
@@ -46,6 +52,7 @@ type SnapshotDataContent = (
     SnapshotLocks,
 );
 /// The latest snapshot kept in memory (`meta` + serialized bytes) for memory-only mode.
+#[cfg(feature = "in-memory-snapshots")]
 type MemSnapshot = (SnapshotMeta<NodeId, Node>, Vec<u8>);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -128,10 +135,14 @@ pub struct StateMachineData {
 pub struct StateMachineMemory {
     data: RwLock<StateMachineData>,
     path_snapshots: String,
+    /// Whether the cache runs fully in-memory (`cache_storage_disk = false`). Only relevant
+    /// with the `in-memory-snapshots` feature, which is the only mode that skips `data_dir`.
+    #[cfg(feature = "in-memory-snapshots")]
     in_memory_only: bool,
     /// Holds the latest snapshot when running purely in-memory (`in_memory_only == true`).
     /// In that mode nothing is ever written to `data_dir`, so a cache-only node does not
     /// require it to exist or be writable. Unused (always `None`) when persisting to disk.
+    #[cfg(feature = "in-memory-snapshots")]
     snapshot_mem: RwLock<Option<MemSnapshot>>,
 
     pub(crate) tx_caches: Vec<flume::Sender<CacheRequestHandler>>,
@@ -147,68 +158,24 @@ pub struct StateMachineMemory {
 }
 
 impl RaftSnapshotBuilder<TypeConfigKV> for Arc<StateMachineMemory> {
+    #[cfg(not(feature = "in-memory-snapshots"))]
     async fn build_snapshot(&mut self) -> Result<Snapshot<TypeConfigKV>, StorageError<NodeId>> {
-        let (meta, snapshot_bytes) = {
-            let data = self.data.read().await;
+        let (meta, snapshot_bytes) = self.build_snapshot_data().await?;
+        let path = self.persist_snapshot(&meta, &snapshot_bytes).await?;
 
-            // TODO should we include notifications in snapshots as well?
-            //  -> unsure if it makes sense or not
+        // Stream the snapshot straight from the persisted file (zero-copy).
+        let file = fs::File::open(&path)
+            .await
+            .map_err(|err| StorageIOError::read_state_machine(&err))?;
+        Ok(Snapshot {
+            meta,
+            snapshot: Box::new(file),
+        })
+    }
 
-            let mut ttls = Vec::with_capacity(self.tx_ttls.len());
-            for tx in &self.tx_ttls {
-                let (ack, rx) = oneshot::channel();
-                tx.send(TtlRequest::SnapshotBuild(ack))
-                    .expect("ttl handler to always be running");
-                let snap = rx
-                    .await
-                    .expect("to always receive an answer from ttl handler");
-                ttls.push(snap);
-            }
-
-            let mut caches = Vec::with_capacity(self.tx_caches.len());
-            for tx in &self.tx_caches {
-                let (ack, rx) = oneshot::channel();
-                tx.send(CacheRequestHandler::SnapshotBuild(ack))
-                    .expect("kv handler to always be running");
-                let snap = rx
-                    .await
-                    .expect("to always receive an answer from kv handler");
-                caches.push(snap);
-            }
-
-            #[cfg(feature = "dlock")]
-            let locks_bytes = {
-                let (ack, rx) = oneshot::channel();
-                self.tx_dlock
-                    .send(LockRequest::SnapshotBuild(ack))
-                    .expect("locks handler to always be running");
-                let locks = rx
-                    .await
-                    .expect("to always receive an answer from locks handler");
-                serialize(&locks).unwrap()
-            };
-            #[cfg(not(feature = "dlock"))]
-            let locks_bytes: Vec<u8> = Vec::default();
-
-            let now = Utc::now().timestamp();
-            let snapshot_id = if let Some(last) = data.last_applied_log_id {
-                format!("{}-{}-{}", now, last.leader_id, last.index)
-            } else {
-                format!("{now}--")
-            };
-
-            let meta = SnapshotMeta {
-                last_log_id: data.last_applied_log_id,
-                last_membership: data.last_membership.clone(),
-                snapshot_id,
-            };
-
-            let snap: SnapshotDataContent = (meta.clone(), caches, ttls, locks_bytes);
-            let snapshot_bytes =
-                serialize(&snap).map_err(|err| StorageIOError::write_state_machine(&err))?;
-
-            (meta, snapshot_bytes)
-        };
+    #[cfg(feature = "in-memory-snapshots")]
+    async fn build_snapshot(&mut self) -> Result<Snapshot<TypeConfigKV>, StorageError<NodeId>> {
+        let (meta, snapshot_bytes) = self.build_snapshot_data().await?;
 
         // In memory-only mode we keep the snapshot in memory and never touch `data_dir`,
         // so a pure cache-only node does not require it to exist or be writable.
@@ -220,35 +187,8 @@ impl RaftSnapshotBuilder<TypeConfigKV> for Arc<StateMachineMemory> {
             });
         }
 
-        let path = format!("{}/{}", self.path_snapshots, meta.snapshot_id);
-        let path_temp = format!("{path}.temp");
-        {
-            let mut file = fs::File::create_new(&path_temp)
-                .await
-                .map_err(|err| StorageIOError::write_state_machine(&err))?;
-            file.write_all(&snapshot_bytes)
-                .await
-                .map_err(|err| StorageIOError::write_state_machine(&err))?;
-        }
-
-        fs::copy(&path_temp, &path)
-            .await
-            .map_err(|err| StorageIOError::write_state_machine(&err))?;
-
-        // cleanup task for old snapshots
-        let id = meta.snapshot_id.clone();
-        let path = self.path_snapshots.clone();
-        task::spawn(async move {
-            let mut dir = fs::read_dir(&path).await.unwrap();
-            while let Ok(Some(entry)) = dir.next_entry().await {
-                let fname = entry.file_name();
-                let name = fname.to_str().unwrap_or_default();
-                if !name.is_empty() && name != id {
-                    fs::remove_file(format!("{path}/{name}")).await.unwrap();
-                }
-            }
-        });
-
+        // Disk-backed: persist exactly like the default path, but stream from memory.
+        self.persist_snapshot(&meta, &snapshot_bytes).await?;
         Ok(Snapshot {
             meta,
             snapshot: Box::new(Cursor::new(snapshot_bytes)),
@@ -264,9 +204,22 @@ impl StateMachineMemory {
         let path_sm = format!("{base_path}/state_machine_cache");
         let path_snapshots = format!("{path_sm}/snapshots");
 
-        // In memory-only mode we never persist snapshots, so we must not touch `data_dir`
-        // at all: it does not need to exist for a pure cache-only node. When persisting to
-        // disk we create (and keep) the snapshot dir so existing snapshots survive a restart.
+        // Default: snapshots are always persisted, so `data_dir` is always required.
+        #[cfg(not(feature = "in-memory-snapshots"))]
+        {
+            if in_memory_only {
+                // in this case we must always start clean,
+                // because otherwise there would be a gap in logs
+                let _ = fs::remove_dir_all(&path_snapshots).await;
+            }
+            fs::create_dir_all(&path_snapshots).await?;
+            set_path_access(&path_sm, 0o700)
+                .await
+                .expect("Cannot set access rights for path_sm");
+        }
+        // With `in-memory-snapshots`, a memory-only node never persists snapshots and must
+        // not touch `data_dir` at all. Disk-backed nodes still create (and keep) the dir.
+        #[cfg(feature = "in-memory-snapshots")]
         if !in_memory_only {
             fs::create_dir_all(&path_snapshots).await?;
             set_path_access(&path_sm, 0o700)
@@ -293,7 +246,9 @@ impl StateMachineMemory {
         let slf = Self {
             data: RwLock::new(StateMachineData::default()),
             path_snapshots,
+            #[cfg(feature = "in-memory-snapshots")]
             in_memory_only,
+            #[cfg(feature = "in-memory-snapshots")]
             snapshot_mem: RwLock::new(None),
             tx_caches,
             tx_ttls,
@@ -305,8 +260,18 @@ impl StateMachineMemory {
             tx_dlock,
         };
 
-        // Only disk-backed snapshots can be restored on startup. In memory-only mode the
-        // snapshot lives in `snapshot_mem` and starts empty, so there is nothing to read.
+        // Restore the latest persisted snapshot on startup.
+        #[cfg(not(feature = "in-memory-snapshots"))]
+        if let Some((_, content)) = slf
+            .read_current_snapshot()
+            .await
+            .expect("Cannot read current snapshot")
+        {
+            slf.update_state_machine(content).await;
+        }
+        // In memory-only mode the snapshot lives in `snapshot_mem` and starts empty, so there
+        // is nothing on disk to read; disk-backed nodes still restore from `data_dir`.
+        #[cfg(feature = "in-memory-snapshots")]
         if !in_memory_only
             && let Some((_, content)) = slf
                 .read_current_snapshot()
@@ -317,6 +282,129 @@ impl StateMachineMemory {
         }
 
         Ok(slf)
+    }
+
+    /// Serializes the current cache state (caches, TTLs, locks) into a snapshot blob.
+    /// Shared by the disk-backed (default) and in-memory (`in-memory-snapshots`) paths.
+    async fn build_snapshot_data(
+        &self,
+    ) -> Result<(SnapshotMeta<NodeId, Node>, Vec<u8>), StorageError<NodeId>> {
+        let data = self.data.read().await;
+
+        // TODO should we include notifications in snapshots as well?
+        //  -> unsure if it makes sense or not
+
+        let mut ttls = Vec::with_capacity(self.tx_ttls.len());
+        for tx in &self.tx_ttls {
+            let (ack, rx) = oneshot::channel();
+            tx.send(TtlRequest::SnapshotBuild(ack))
+                .expect("ttl handler to always be running");
+            let snap = rx
+                .await
+                .expect("to always receive an answer from ttl handler");
+            ttls.push(snap);
+        }
+
+        let mut caches = Vec::with_capacity(self.tx_caches.len());
+        for tx in &self.tx_caches {
+            let (ack, rx) = oneshot::channel();
+            tx.send(CacheRequestHandler::SnapshotBuild(ack))
+                .expect("kv handler to always be running");
+            let snap = rx
+                .await
+                .expect("to always receive an answer from kv handler");
+            caches.push(snap);
+        }
+
+        #[cfg(feature = "dlock")]
+        let locks_bytes = {
+            let (ack, rx) = oneshot::channel();
+            self.tx_dlock
+                .send(LockRequest::SnapshotBuild(ack))
+                .expect("locks handler to always be running");
+            let locks = rx
+                .await
+                .expect("to always receive an answer from locks handler");
+            serialize(&locks).unwrap()
+        };
+        #[cfg(not(feature = "dlock"))]
+        let locks_bytes: Vec<u8> = Vec::default();
+
+        let now = Utc::now().timestamp();
+        let snapshot_id = if let Some(last) = data.last_applied_log_id {
+            format!("{}-{}-{}", now, last.leader_id, last.index)
+        } else {
+            format!("{now}--")
+        };
+
+        let meta = SnapshotMeta {
+            last_log_id: data.last_applied_log_id,
+            last_membership: data.last_membership.clone(),
+            snapshot_id,
+        };
+
+        let snap: SnapshotDataContent = (meta.clone(), caches, ttls, locks_bytes);
+        let snapshot_bytes =
+            serialize(&snap).map_err(|err| StorageIOError::write_state_machine(&err))?;
+
+        Ok((meta, snapshot_bytes))
+    }
+
+    /// Persists a serialized snapshot to `data_dir` and spawns cleanup of older snapshots.
+    /// Returns the path of the persisted snapshot file.
+    async fn persist_snapshot(
+        &self,
+        meta: &SnapshotMeta<NodeId, Node>,
+        snapshot_bytes: &[u8],
+    ) -> Result<String, StorageError<NodeId>> {
+        let path = format!("{}/{}", self.path_snapshots, meta.snapshot_id);
+        let path_temp = format!("{path}.temp");
+        {
+            let mut file = fs::File::create_new(&path_temp)
+                .await
+                .map_err(|err| StorageIOError::write_state_machine(&err))?;
+            file.write_all(snapshot_bytes)
+                .await
+                .map_err(|err| StorageIOError::write_state_machine(&err))?;
+        }
+
+        fs::copy(&path_temp, &path)
+            .await
+            .map_err(|err| StorageIOError::write_state_machine(&err))?;
+
+        // cleanup task for old snapshots
+        let id = meta.snapshot_id.clone();
+        let dir = self.path_snapshots.clone();
+        task::spawn(async move {
+            let mut entries = fs::read_dir(&dir).await.unwrap();
+            while let Ok(Some(entry)) = entries.next_entry().await {
+                let fname = entry.file_name();
+                let name = fname.to_str().unwrap_or_default();
+                if !name.is_empty() && name != id {
+                    fs::remove_file(format!("{dir}/{name}")).await.unwrap();
+                }
+            }
+        });
+
+        Ok(path)
+    }
+
+    /// Deserializes a snapshot blob and applies it to the in-memory state.
+    async fn apply_snapshot_bytes(
+        &self,
+        meta: &SnapshotMeta<NodeId, Node>,
+        bytes: &[u8],
+    ) -> Result<(), StorageError<NodeId>> {
+        let (meta_snap, kvs, ttls, locks) = deserialize::<SnapshotDataContent>(bytes)
+            .map_err(|e| StorageIOError::read_snapshot(Some(meta.signature()), &e))?;
+        debug_assert_eq!(meta.snapshot_id, meta_snap.snapshot_id);
+        debug_assert_eq!(meta.last_log_id, meta_snap.last_log_id);
+        debug_assert_eq!(meta.last_membership, meta_snap.last_membership);
+
+        self.update_state_machine((meta_snap, kvs, ttls, locks))
+            .await;
+
+        Ok(())
     }
 
     async fn update_state_machine(&self, content: SnapshotDataContent) {
@@ -692,6 +780,26 @@ impl RaftStateMachine<TypeConfigKV> for Arc<StateMachineMemory> {
         self.clone()
     }
 
+    #[cfg(not(feature = "in-memory-snapshots"))]
+    #[tracing::instrument(skip_all)]
+    async fn begin_receiving_snapshot(
+        &mut self,
+    ) -> Result<Box<SnapshotData>, StorageError<NodeId>> {
+        let path = format!("{}/temp", self.path_snapshots);
+        info!("Saving incoming snapshot to {}", path);
+
+        // clean up possible existing old data
+        let _ = fs::remove_file(&path).await;
+
+        match fs::File::create(path).await {
+            Ok(file) => Ok(Box::new(file)),
+            Err(err) => Err(StorageError::IO {
+                source: StorageIOError::write(&err),
+            }),
+        }
+    }
+
+    #[cfg(feature = "in-memory-snapshots")]
     #[tracing::instrument(skip_all)]
     async fn begin_receiving_snapshot(
         &mut self,
@@ -701,6 +809,34 @@ impl RaftStateMachine<TypeConfigKV> for Arc<StateMachineMemory> {
         Ok(Box::new(Cursor::new(Vec::new())))
     }
 
+    #[cfg(not(feature = "in-memory-snapshots"))]
+    #[tracing::instrument(skip_all)]
+    async fn install_snapshot(
+        &mut self,
+        meta: &SnapshotMeta<NodeId, Node>,
+        // the streamed data already lives in the temp file created by `begin_receiving_snapshot`
+        _snapshot: Box<SnapshotData>,
+    ) -> Result<(), StorageError<NodeId>> {
+        let src = format!("{}/temp", self.path_snapshots);
+        let dest = format!("{}/{}", self.path_snapshots, meta.snapshot_id);
+        fs::copy(&src, &dest)
+            .await
+            .map_err(|err| StorageError::IO {
+                source: StorageIOError::write(&err),
+            })?;
+
+        fs::remove_file(src).await.map_err(|err| StorageError::IO {
+            source: StorageIOError::write(&err),
+        })?;
+
+        let bytes = fs::read(dest)
+            .await
+            .map_err(|e| StorageIOError::read_snapshot(Some(meta.signature()), &e))?;
+
+        self.apply_snapshot_bytes(meta, &bytes).await
+    }
+
+    #[cfg(feature = "in-memory-snapshots")]
     #[tracing::instrument(skip_all)]
     async fn install_snapshot(
         &mut self,
@@ -720,18 +856,31 @@ impl RaftStateMachine<TypeConfigKV> for Arc<StateMachineMemory> {
                 })?;
         }
 
-        let (meta_snap, kvs, ttls, locks) = deserialize::<SnapshotDataContent>(&bytes)
-            .map_err(|e| StorageIOError::read_snapshot(Some(meta.signature()), &e))?;
-        debug_assert_eq!(meta.snapshot_id, meta_snap.snapshot_id);
-        debug_assert_eq!(meta.last_log_id, meta_snap.last_log_id);
-        debug_assert_eq!(meta.last_membership, meta_snap.last_membership);
-
-        self.update_state_machine((meta_snap, kvs, ttls, locks))
-            .await;
-
-        Ok(())
+        self.apply_snapshot_bytes(meta, &bytes).await
     }
 
+    #[cfg(not(feature = "in-memory-snapshots"))]
+    async fn get_current_snapshot(
+        &mut self,
+    ) -> Result<Option<Snapshot<TypeConfigKV>>, StorageError<NodeId>> {
+        match self.read_current_snapshot().await? {
+            None => Ok(None),
+            Some((path, (meta, ..))) => {
+                let file = fs::File::open(path).await.map_err(|err| StorageError::IO {
+                    source: StorageIOError::read(&err),
+                })?;
+
+                let snapshot = Snapshot {
+                    meta,
+                    snapshot: Box::new(file),
+                };
+
+                Ok(Some(snapshot))
+            }
+        }
+    }
+
+    #[cfg(feature = "in-memory-snapshots")]
     async fn get_current_snapshot(
         &mut self,
     ) -> Result<Option<Snapshot<TypeConfigKV>>, StorageError<NodeId>> {
@@ -761,7 +910,7 @@ impl RaftStateMachine<TypeConfigKV> for Arc<StateMachineMemory> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "in-memory-snapshots"))]
 mod tests {
     use super::*;
     use crate::CacheVariants;

--- a/justfile
+++ b/justfile
@@ -92,6 +92,7 @@ clippy:
     cargo clippy --no-default-features --features sqlite,auto-heal,backup -- -D warnings
 
     cargo clippy --no-default-features --features cache -- -D warnings
+    cargo clippy --no-default-features --features in-memory-snapshots -- -D warnings
     cargo clippy --no-default-features --features counters -- -D warnings
     cargo clippy --no-default-features --features dlock -- -D warnings
     cargo clippy --no-default-features --features listen_notify_local -- -D warnings


### PR DESCRIPTION
## Summary

Make a pure cache-only node run fully in-memory when `cache_storage_disk = false`, so that `data_dir` is no longer required to exist or be writable. This is an opt-in alternative to requiring `data_dir` in cache-only mode (see #289).

## Background

#289 documents that even in cache-only mode `data_dir` must exist and be writable, and improves the error when it can't be created. While tracing *why* that requirement exists, it comes down to a single place: the in-memory cache state machine always persists its snapshots to disk, even when the cache WAL is kept in memory.

For a pure cache-only node with `cache_storage_disk = false`:

- the cache Raft log store is already fully in-memory (`LogStoreMemory`), but
- `StateMachineMemory` still calls `create_dir_all({data_dir}/state_machine_cache/snapshots)` and writes snapshot files there.

That also contradicts the `cache_storage_disk` doc, which promises that `false` keeps "the cache WAL **+ Snapshots** ... in memory". The WAL was in memory; the snapshots were not.

## Change

- `TypeConfigKV::SnapshotData`: `tokio::fs::File` -> `Cursor<Vec<u8>>`. This decouples the Raft snapshot transport type from on-disk persistence. The snapshot is already fully serialized into a `Vec<u8>` before being written, and received snapshots were already read back into a `Vec<u8>` before applying, so the memory profile is unchanged. This is the same `SnapshotData` type openraft's own mem-store examples use, and the chunked `InstallSnapshotRequest` transport is unaffected.
- `StateMachineMemory`: when `in_memory_only` (i.e. `cache_storage_disk = false`), keep the latest snapshot in memory and never touch `data_dir` in `new` / `build_snapshot` / `begin_receiving_snapshot` / `install_snapshot` / `get_current_snapshot`.
- Disk-backed behavior (`cache_storage_disk = true`) is unchanged: snapshots are still written to and restored from `data_dir`.
- Docs (`hiqlite.toml`, `NodeConfig` doc comments) now explain that `data_dir` is not required for a pure cache-only, in-memory node.
- Added a unit test asserting an in-memory cache node creates nothing on disk and can still build and retrieve a snapshot.

## Relationship to #289

Complementary, not competing: when `data_dir` genuinely *is* used (disk-backed cache, or SQLite), the clearer error message from #289 is still the right thing. This PR removes the requirement entirely for the fully in-memory cache-only case, which is the scenario that motivated the issue.

## Testing

- `cargo clippy --no-default-features --features cache` and `--features sqlite,cache`: clean.
- `cargo clippy -- -D warnings` (default features): clean.
- New unit test passes. The existing cluster test suite already runs with `cache_storage_disk = false`, so it exercises the in-memory snapshot path end-to-end, including snapshot transfer during self-healing.
