### PR TITLE
fix(derive): Out-of-range from_i32 values error instead of being silently clamped

### DIFF
--- a/hiqlite-derive/src/from_row.rs
+++ b/hiqlite-derive/src/from_row.rs
@@ -2,7 +2,7 @@ use proc_macro2::{Literal, TokenStream, TokenTree};
 use quote::quote;
 use syn::{Attribute, Data, DeriveInput, Meta, MetaList, Type};
 
-pub fn impl_from_row(input: DeriveInput) -> proc_macro::TokenStream {
+pub fn impl_from_row(input: DeriveInput) -> proc_macro2::TokenStream {
     let name = input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
@@ -28,25 +28,21 @@ pub fn impl_from_row(input: DeriveInput) -> proc_macro::TokenStream {
                         quote! {#id: ::std::convert::TryFrom::try_from(&mut *row).unwrap(),}
                     }
                     ColumnAttr::FromI32 => {
+                        // out-of-range values must fail loudly instead of being silently
+                        // clamped to a wrong value
+                        let convert = quote! {
+                            <i32 as ::std::convert::TryFrom<i64>>::try_from(i)
+                                .expect("column value does not fit into i32")
+                                .into()
+                        };
                         if is_opt {
                             quote! {
-                                #id: row.get::<Option<i64>>(#name)
-                                    .map(|i| {
-                                        if i > 0 {
-                                            (::std::cmp::min(i, i32::MAX as i64) as i32).into()
-                                        } else {
-                                            (::std::cmp::max(i, i32::MIN as i64) as i32).into()
-                                        }
-                                    }),
+                                #id: row.get::<Option<i64>>(#name).map(|i| #convert),
                             }
                         } else {
                             quote! {#id: {
                                 let i = row.get::<i64>(#name);
-                                if i > 0 {
-                                    (::std::cmp::min(i, i32::MAX as i64) as i32).into()
-                                } else {
-                                    (::std::cmp::max(i, i32::MIN as i64) as i32).into()
-                                }
+                                #convert
                             },}
                         }
                     }
@@ -102,7 +98,7 @@ pub fn impl_from_row(input: DeriveInput) -> proc_macro::TokenStream {
                 }
             }
         }
-    }.into()
+    }
 }
 
 #[inline]
@@ -255,5 +251,54 @@ Invalid syntax for '#[column]' - '{idx}' attribute, expected one of:
         }
 
         Self { rename, attr }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quote::ToTokens;
+
+    fn generate(src: &str) -> String {
+        let input: DeriveInput = syn::parse_str(src).unwrap();
+        impl_from_row(input).into_token_stream().to_string()
+    }
+
+    #[test]
+    fn from_i32_uses_try_from_and_never_clamps() {
+        let out = generate(
+            r#"struct Test { #[column(from_i32)] a: i32, #[column(from_i32)] b: Option<i32> }"#,
+        );
+        // token streams render with spaces around `::`
+        let compact = out.replace(' ', "");
+        assert!(
+            compact.contains("TryFrom<i64>>::try_from"),
+            "missing try_from: {out}"
+        );
+        assert!(
+            !compact.contains("cmp::min"),
+            "silent clamp still present: {out}"
+        );
+        assert!(
+            !compact.contains("cmp::max"),
+            "silent clamp still present: {out}"
+        );
+        assert!(
+            out.contains("does not fit into i32"),
+            "no panic message: {out}"
+        );
+    }
+
+    #[test]
+    fn basic_mapping_uses_row_get_by_column_name() {
+        let out = generate(
+            r#"struct Test { #[column(rename = "name_db")] name: String, skip_me: bool }"#,
+        );
+        let compact = out.replace(' ', "");
+        assert!(
+            compact.contains("From<&mut::hiqlite::Row"),
+            "no From impl: {out}"
+        );
+        assert!(out.contains("name_db"), "rename not honored: {out}");
     }
 }

--- a/hiqlite-derive/src/lib.rs
+++ b/hiqlite-derive/src/lib.rs
@@ -10,7 +10,7 @@ mod into_cache_data;
 #[proc_macro_derive(FromRow, attributes(column))]
 pub fn from_row(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     // TODO could be reworked into returning a result, which would make the impl a bit cleaner
-    impl_from_row(parse_macro_input!(input as DeriveInput))
+    impl_from_row(parse_macro_input!(input as DeriveInput)).into()
 }
 
 #[proc_macro_derive(CacheVariants)]


### PR DESCRIPTION
## Summary

The `#[column(from_i32)]` attribute of the `FromRow` derive silently clamped `BIGINT` values to the `i32` range. A value like `5_000_000_000` was returned as `2_147_483_647` with no warning — a wrong result presented as a correct one.

This change makes the mapping fail loudly: out-of-range values now trigger a clear panic inside the generated `From` implementation, which surfaces to the caller as a query error through the existing `spawn_blocking` boundary instead of corrupting results.

## Changes

- `from_i32` (both plain and `Option` fields) now uses `i32::try_from(i64)` and panics with a descriptive message on overflow; the silent `cmp::min` / `cmp::max` clamping is removed.
- The derive internals return `proc_macro2::TokenStream` instead of `proc_macro::TokenStream` so the generated code can be unit-tested outside a macro-expansion context.
- Unit tests assert the generated code uses `TryFrom`, contains no clamping, and honors column renames.

## Verification

- `cargo test -p hiqlite-derive` — 2 passed.
- `cargo clippy -p hiqlite-derive -- -D warnings` — clean.
- `cargo test -p hiqlite --lib --features full` — 22 passed (generated code compiles in the full feature set).

## Compatibility notes

Behavior change: a column that previously silently clamped now errors. This is intentional. A fully fallible mapping (a `TryFromRow`-style trait) remains a future API decision; the existing data-triggered panics of `parse`, `flatten`, and plain column mapping are inherent to the infallible `From<&mut Row>` trait.

Developed with carefully directed, manually reviewed AI assistance.