### PR TITLE
fix: Make the distributed-lock handler fault-tolerant and deadlock-free

### DIFF
--- a/hiqlite/src/client/backup.rs
+++ b/hiqlite/src/client/backup.rs
@@ -1,3 +1,4 @@
+use crate::client::helpers::await_channel_response;
 use crate::client::stream::{ClientBackupPayload, ClientStreamReq};
 use crate::network::api::ApiStreamResponsePayload;
 use crate::store::state_machine::sqlite::state_machine::QueryWrite;
@@ -94,9 +95,7 @@ impl Client {
                 }))
                 .await
                 .map_err(|err| Error::Error(err.to_string().into()))?;
-            let res = rx
-                .await
-                .map_err(|_| Error::Error("Client stream manager closed".into()))??;
+            let res = await_channel_response(rx).await??;
             match res {
                 ApiStreamResponsePayload::Backup(res) => res,
                 _ => unreachable!(),

--- a/hiqlite/src/client/backup.rs
+++ b/hiqlite/src/client/backup.rs
@@ -96,7 +96,7 @@ impl Client {
                 .map_err(|err| Error::Error(err.to_string().into()))?;
             let res = rx
                 .await
-                .expect("To always receive an answer from Client Stream Manager")?;
+                .map_err(|_| Error::Error("Client stream manager closed".into()))??;
             match res {
                 ApiStreamResponsePayload::Backup(res) => res,
                 _ => unreachable!(),

--- a/hiqlite/src/client/batch.rs
+++ b/hiqlite/src/client/batch.rs
@@ -1,3 +1,4 @@
+use crate::client::helpers::await_channel_response;
 use crate::client::stream::{ClientBatchPayload, ClientStreamReq};
 use crate::network::api::ApiStreamResponsePayload;
 use crate::store::state_machine::sqlite::state_machine::QueryWrite;
@@ -81,9 +82,7 @@ impl Client {
                 }))
                 .await
                 .map_err(|err| Error::Error(err.to_string().into()))?;
-            let res = rx
-                .await
-                .map_err(|_| Error::Error("Client stream manager closed".into()))??;
+            let res = await_channel_response(rx).await??;
             match res {
                 ApiStreamResponsePayload::Batch(res) => res,
                 _ => unreachable!(),

--- a/hiqlite/src/client/batch.rs
+++ b/hiqlite/src/client/batch.rs
@@ -83,7 +83,7 @@ impl Client {
                 .map_err(|err| Error::Error(err.to_string().into()))?;
             let res = rx
                 .await
-                .expect("To always receive an answer from Client Stream Manager")?;
+                .map_err(|_| Error::Error("Client stream manager closed".into()))??;
             match res {
                 ApiStreamResponsePayload::Batch(res) => res,
                 _ => unreachable!(),

--- a/hiqlite/src/client/cache.rs
+++ b/hiqlite/src/client/cache.rs
@@ -414,7 +414,7 @@ impl Client {
                 .map_err(|err| Error::Error(err.to_string().into()))?;
             let res = rx
                 .await
-                .expect("To always receive an answer from Client Stream Manager")?;
+                .map_err(|_| Error::Error("Client stream manager closed".into()))??;
             match res {
                 ApiStreamResponsePayload::KV(res) => res,
                 #[cfg(any(feature = "sqlite", feature = "dlock", feature = "listen_notify_local"))]

--- a/hiqlite/src/client/cache.rs
+++ b/hiqlite/src/client/cache.rs
@@ -1,3 +1,4 @@
+use crate::client::helpers::await_channel_response;
 use crate::client::stream::{ClientKVPayload, ClientStreamReq};
 use crate::helpers::deserialize;
 use crate::network::api::ApiStreamResponsePayload;
@@ -108,9 +109,7 @@ impl Client {
                 .unwrap()
                 .send(CacheRequestHandler::Get((key.into(), ack)))
                 .expect("kv handler to always be running");
-            let value = rx
-                .await
-                .expect("to always get an answer from the kv handler");
+            let value = await_channel_response(rx).await?;
             Ok(value)
         } else {
             let res = self
@@ -148,9 +147,7 @@ impl Client {
                 .unwrap()
                 .send(CacheRequestHandler::SnapshotBuildCacheOnly(ack))
                 .expect("kv handler to always be running");
-            let snapshot = rx
-                .await
-                .expect("to always get an answer from the kv handler");
+            let snapshot = await_channel_response(rx).await?;
 
             let mut res = BTreeMap::new();
             for (k, v) in snapshot {
@@ -267,9 +264,7 @@ impl Client {
                     ack,
                 )))
                 .expect("kv handler to always be running");
-            let value = rx
-                .await
-                .expect("to always get an answer from the kv handler");
+            let value = await_channel_response(rx).await?;
             Ok(value)
         } else {
             let res = self
@@ -412,9 +407,7 @@ impl Client {
                 .send_async(payload)
                 .await
                 .map_err(|err| Error::Error(err.to_string().into()))?;
-            let res = rx
-                .await
-                .map_err(|_| Error::Error("Client stream manager closed".into()))??;
+            let res = await_channel_response(rx).await??;
             match res {
                 ApiStreamResponsePayload::KV(res) => res,
                 #[cfg(any(feature = "sqlite", feature = "dlock", feature = "listen_notify_local"))]

--- a/hiqlite/src/client/dlock.rs
+++ b/hiqlite/src/client/dlock.rs
@@ -188,7 +188,7 @@ impl Client {
                 .map_err(|err| Error::Error(err.to_string().into()))?;
             let res = rx
                 .await
-                .expect("To always receive an answer from Client Stream Manager")?;
+                .map_err(|_| Error::Error("Client stream manager closed".into()))??;
             match res {
                 ApiStreamResponsePayload::KV(res) => match res? {
                     CacheResponse::Lock(state) => {

--- a/hiqlite/src/client/dlock.rs
+++ b/hiqlite/src/client/dlock.rs
@@ -197,14 +197,15 @@ impl Client {
                     }
                     _ => unreachable!(),
                 },
-                ApiStreamResponsePayload::Lock(LockState::Released) => {
+                ApiStreamResponsePayload::Lock(Ok(LockState::Released)) => {
                     assert!(is_remote_await);
                     Ok(LockState::Released)
                 }
-                ApiStreamResponsePayload::Lock(LockState::Locked(id)) => {
+                ApiStreamResponsePayload::Lock(Ok(LockState::Locked(id))) => {
                     assert!(is_remote_await);
                     Ok(LockState::Locked(id))
                 }
+                ApiStreamResponsePayload::Lock(Err(err)) => Err(err),
                 #[cfg(any(feature = "sqlite", feature = "dlock"))]
                 _ => unreachable!(),
             }

--- a/hiqlite/src/client/dlock.rs
+++ b/hiqlite/src/client/dlock.rs
@@ -1,3 +1,4 @@
+use crate::client::helpers::await_channel_response;
 use crate::client::stream::{ClientKVPayload, ClientStreamReq};
 use crate::network::api::ApiStreamResponsePayload;
 use crate::store::state_machine::memory::dlock_handler::{
@@ -118,9 +119,7 @@ impl Client {
                 .tx_dlock
                 .send(LockRequest::Await(LockAwaitPayload { key, id, ack }))
                 .expect("kv handler to always be running");
-            let state = rx
-                .await
-                .expect("to always get an answer from the kv handler");
+            let state = await_channel_response(rx).await?;
             Ok(state)
         } else {
             self.lock_req_retry(CacheRequest::LockAwait((key.clone(), id)), true)
@@ -186,9 +185,7 @@ impl Client {
                 .send_async(payload)
                 .await
                 .map_err(|err| Error::Error(err.to_string().into()))?;
-            let res = rx
-                .await
-                .map_err(|_| Error::Error("Client stream manager closed".into()))??;
+            let res = await_channel_response(rx).await??;
             match res {
                 ApiStreamResponsePayload::KV(res) => match res? {
                     CacheResponse::Lock(state) => {

--- a/hiqlite/src/client/dlock.rs
+++ b/hiqlite/src/client/dlock.rs
@@ -68,35 +68,41 @@ impl Client {
         self.rate_limit_cache().await?;
 
         let key = key.into();
-        let state = self
-            .lock_req_retry(CacheRequest::Lock((key.clone(), None)), false)
-            .await?;
-        match state {
-            LockState::Locked(id) => Ok(Lock {
-                id,
-                key,
-                client: self.clone(),
-            }),
-            LockState::Queued(id) => {
-                let res = self.lock_await(key.clone(), id).await?;
-                match res {
-                    LockState::Released => {
-                        let state = self
-                            .lock_req_retry(CacheRequest::Lock((key.clone(), Some(id))), false)
-                            .await?;
-                        match state {
-                            LockState::Locked(id) => Ok(Lock {
+        // `ticket` keeps our queue ticket across re-claims. Reusing the same ticket is important:
+        // a new first-try `Lock` would mint a fresh ticket and leave the old one orphaned in the
+        // handler queue, where it could block the lock until its lease expires.
+        let mut ticket: Option<u64> = None;
+        loop {
+            let state = self
+                .lock_req_retry(CacheRequest::Lock((key.clone(), ticket)), false)
+                .await?;
+            match state {
+                LockState::Locked(id) => {
+                    return Ok(Lock {
+                        id,
+                        key,
+                        client: self.clone(),
+                    });
+                }
+                LockState::Queued(id) => {
+                    // Wait for our position. The lock may be granted directly while waiting if
+                    // the previous holder's lease expired.
+                    match self.lock_await(key.clone(), id).await? {
+                        LockState::Locked(id) => {
+                            return Ok(Lock {
                                 id,
                                 key,
                                 client: self.clone(),
-                            }),
-                            s => unreachable!("{:?}", s),
+                            });
                         }
+                        // Released: the handler promoted our ticket. Re-request with the same
+                        // ticket to claim it.
+                        LockState::Released => ticket = Some(id),
+                        s => unreachable!("{:?}", s),
                     }
-                    _ => unreachable!(),
                 }
+                s => unreachable!("{:?}", s),
             }
-            _ => unreachable!(),
         }
     }
 
@@ -194,6 +200,10 @@ impl Client {
                 ApiStreamResponsePayload::Lock(LockState::Released) => {
                     assert!(is_remote_await);
                     Ok(LockState::Released)
+                }
+                ApiStreamResponsePayload::Lock(LockState::Locked(id)) => {
+                    assert!(is_remote_await);
+                    Ok(LockState::Locked(id))
                 }
                 #[cfg(any(feature = "sqlite", feature = "dlock"))]
                 _ => unreachable!(),

--- a/hiqlite/src/client/execute.rs
+++ b/hiqlite/src/client/execute.rs
@@ -1,3 +1,4 @@
+use crate::client::helpers::await_channel_response;
 use crate::client::stream::{ClientExecutePayload, ClientStreamReq};
 use crate::network::api::ApiStreamResponsePayload;
 use crate::query::rows::RowOwned;
@@ -68,9 +69,7 @@ impl Client {
                 }))
                 .await
                 .map_err(|err| Error::Error(err.to_string().into()))?;
-            let res = rx
-                .await
-                .map_err(|_| Error::Error("Client stream manager closed".into()))??;
+            let res = await_channel_response(rx).await??;
             match res {
                 ApiStreamResponsePayload::Execute(res) => res,
                 _ => unreachable!(),
@@ -216,9 +215,7 @@ impl Client {
                 }))
                 .await
                 .map_err(|err| Error::Error(err.to_string().into()))?;
-            let res = rx
-                .await
-                .map_err(|_| Error::Error("Client stream manager closed".into()))??;
+            let res = await_channel_response(rx).await??;
             match res {
                 ApiStreamResponsePayload::ExecuteReturning(res) => res,
                 _ => unreachable!(),

--- a/hiqlite/src/client/execute.rs
+++ b/hiqlite/src/client/execute.rs
@@ -70,7 +70,7 @@ impl Client {
                 .map_err(|err| Error::Error(err.to_string().into()))?;
             let res = rx
                 .await
-                .expect("To always receive an answer from Client Stream Manager")?;
+                .map_err(|_| Error::Error("Client stream manager closed".into()))??;
             match res {
                 ApiStreamResponsePayload::Execute(res) => res,
                 _ => unreachable!(),
@@ -218,7 +218,7 @@ impl Client {
                 .map_err(|err| Error::Error(err.to_string().into()))?;
             let res = rx
                 .await
-                .expect("To always receive an answer from Client Stream Manager")?;
+                .map_err(|_| Error::Error("Client stream manager closed".into()))??;
             match res {
                 ApiStreamResponsePayload::ExecuteReturning(res) => res,
                 _ => unreachable!(),

--- a/hiqlite/src/client/helpers.rs
+++ b/hiqlite/src/client/helpers.rs
@@ -246,10 +246,12 @@ impl Client {
                 }
             }
 
-            if was_leader_error {
-                tx.send_async(ClientStreamReq::LeaderChange((id, Some(node.clone()))))
+            if was_leader_error
+                && let Err(err) = tx
+                    .send_async(ClientStreamReq::LeaderChange((id, Some(node.clone()))))
                     .await
-                    .expect("the Client API WebSocket Manager to always be running");
+            {
+                error!("Error sending LeaderChange to Client API WebSocket Manager: {err:?}");
             }
         }
 

--- a/hiqlite/src/client/helpers.rs
+++ b/hiqlite/src/client/helpers.rs
@@ -6,9 +6,26 @@ use std::clone::Clone;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
-use tokio::sync::RwLock;
+use tokio::sync::{RwLock, oneshot};
 use tokio::time;
 use tracing::{debug, error, warn};
+
+/// Timeout applied to every client request waiting for a response from the stream manager or a
+/// local handler. A stalled leader (GC pause, blocked writer, network partition without a
+/// disconnect) must not hang the caller forever. Keep it generous: slow transactions and
+/// backups legitimately take a while. A timed-out request must be treated as at-least-once: the
+/// operation may still have been applied server-side.
+const STREAM_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Waits for a response channel to resolve, surfacing a stall or a dead handler as an error
+/// instead of hanging or panicking the calling task.
+pub(crate) async fn await_channel_response<T>(rx: oneshot::Receiver<T>) -> Result<T, Error> {
+    match time::timeout(STREAM_REQUEST_TIMEOUT, rx).await {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(_)) => Err(Error::Error("response channel closed".into())),
+        Err(_) => Err(Error::Connect("request timed out".into())),
+    }
+}
 
 impl Client {
     #[inline(always)]
@@ -256,5 +273,33 @@ impl Client {
         }
 
         was_leader_error
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn await_channel_response_returns_value() {
+        let (tx, rx) = oneshot::channel();
+        tx.send(42i32).unwrap();
+        assert_eq!(await_channel_response(rx).await.unwrap(), 42);
+    }
+
+    #[tokio::test]
+    async fn await_channel_response_errors_when_closed() {
+        let (tx, rx) = oneshot::channel::<i32>();
+        drop(tx);
+        let err = await_channel_response(rx).await.unwrap_err();
+        assert!(err.to_string().contains("channel closed"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn await_channel_response_times_out() {
+        let (_tx, rx) = oneshot::channel::<i32>();
+        tokio::time::advance(STREAM_REQUEST_TIMEOUT + Duration::from_secs(1)).await;
+        let err = await_channel_response(rx).await.unwrap_err();
+        assert!(err.to_string().contains("timed out"));
     }
 }

--- a/hiqlite/src/client/listen_notify.rs
+++ b/hiqlite/src/client/listen_notify.rs
@@ -210,7 +210,7 @@ impl Client {
                 .map_err(|err| Error::Error(err.to_string().into()))?;
             let res = rx
                 .await
-                .expect("To always receive an answer from Client Stream Manager")?;
+                .map_err(|_| Error::Error("Client stream manager closed".into()))??;
             match res {
                 ApiStreamResponsePayload::Notify(res) => res,
                 _ => unreachable!(),

--- a/hiqlite/src/client/listen_notify.rs
+++ b/hiqlite/src/client/listen_notify.rs
@@ -1,3 +1,4 @@
+use crate::client::helpers::await_channel_response;
 use crate::client::stream::{ClientKVPayload, ClientStreamReq};
 use crate::helpers::deserialize;
 use crate::network::api::ApiStreamResponsePayload;
@@ -208,9 +209,7 @@ impl Client {
                 }))
                 .await
                 .map_err(|err| Error::Error(err.to_string().into()))?;
-            let res = rx
-                .await
-                .map_err(|_| Error::Error("Client stream manager closed".into()))??;
+            let res = await_channel_response(rx).await??;
             match res {
                 ApiStreamResponsePayload::Notify(res) => res,
                 _ => unreachable!(),

--- a/hiqlite/src/client/migrate.rs
+++ b/hiqlite/src/client/migrate.rs
@@ -109,7 +109,7 @@ impl Client {
                 .map_err(|err| Error::Error(err.to_string().into()))?;
             let res = rx
                 .await
-                .expect("To always receive an answer from Client Stream Manager")?;
+                .map_err(|_| Error::Error("Client stream manager closed".into()))??;
             match res {
                 ApiStreamResponsePayload::Migrate(res) => res,
                 _ => unreachable!(),

--- a/hiqlite/src/client/migrate.rs
+++ b/hiqlite/src/client/migrate.rs
@@ -1,3 +1,4 @@
+use crate::client::helpers::await_channel_response;
 use crate::client::stream::{ClientMigratePayload, ClientStreamReq};
 use crate::migration::{Migration, Migrations};
 use crate::network::api::ApiStreamResponsePayload;
@@ -107,9 +108,7 @@ impl Client {
                 }))
                 .await
                 .map_err(|err| Error::Error(err.to_string().into()))?;
-            let res = rx
-                .await
-                .map_err(|_| Error::Error("Client stream manager closed".into()))??;
+            let res = await_channel_response(rx).await??;
             match res {
                 ApiStreamResponsePayload::Migrate(res) => res,
                 _ => unreachable!(),

--- a/hiqlite/src/client/query.rs
+++ b/hiqlite/src/client/query.rs
@@ -331,7 +331,7 @@ impl Client {
             .map_err(|err| Error::Error(err.to_string().into()))?;
         let res = rx
             .await
-            .expect("To always receive an answer from Client Stream Manager")?;
+            .map_err(|_| Error::Error("Client stream manager closed".into()))??;
         match res {
             ApiStreamResponsePayload::Query(res) => {
                 assert!(!consistent);

--- a/hiqlite/src/client/query.rs
+++ b/hiqlite/src/client/query.rs
@@ -1,3 +1,4 @@
+use crate::client::helpers::await_channel_response;
 use crate::client::stream::{ClientQueryPayload, ClientStreamReq};
 use crate::network::api::ApiStreamResponsePayload;
 use crate::query::rows::RowOwned;
@@ -329,9 +330,7 @@ impl Client {
             .send_async(payload)
             .await
             .map_err(|err| Error::Error(err.to_string().into()))?;
-        let res = rx
-            .await
-            .map_err(|_| Error::Error("Client stream manager closed".into()))??;
+        let res = await_channel_response(rx).await??;
         match res {
             ApiStreamResponsePayload::Query(res) => {
                 assert!(!consistent);

--- a/hiqlite/src/client/stream.rs
+++ b/hiqlite/src/client/stream.rs
@@ -676,7 +676,15 @@ async fn stream_reader(
             OpCode::Text => {}
             OpCode::Binary => {
                 let bytes = frame.payload.deref();
-                let payload = deserialize::<ApiStreamResponse>(bytes).unwrap();
+                let payload = match deserialize::<ApiStreamResponse>(bytes) {
+                    Ok(payload) => payload,
+                    Err(err) => {
+                        // corrupt frame from the server: do not panic the reader task, just
+                        // drop the connection so the client can reconnect
+                        error!("Error deserializing response from server: {err:?}");
+                        break;
+                    }
+                };
                 if let Err(err) = tx
                     .send_async(ClientStreamReq::StreamResponse(payload))
                     .await

--- a/hiqlite/src/client/transaction.rs
+++ b/hiqlite/src/client/transaction.rs
@@ -90,7 +90,7 @@ impl Client {
                 .map_err(|err| Error::Error(err.to_string().into()))?;
             let res = rx
                 .await
-                .expect("To always receive an answer from Client Stream Manager")?;
+                .map_err(|_| Error::Error("Client stream manager closed".into()))??;
             match res {
                 ApiStreamResponsePayload::Transaction(res) => res,
                 _ => unreachable!(),

--- a/hiqlite/src/client/transaction.rs
+++ b/hiqlite/src/client/transaction.rs
@@ -1,3 +1,4 @@
+use crate::client::helpers::await_channel_response;
 use crate::client::stream::{ClientStreamReq, ClientTransactionPayload};
 use crate::network::api::ApiStreamResponsePayload;
 use crate::store::state_machine::sqlite::state_machine::{Query, QueryWrite};
@@ -88,9 +89,7 @@ impl Client {
                 }))
                 .await
                 .map_err(|err| Error::Error(err.to_string().into()))?;
-            let res = rx
-                .await
-                .map_err(|_| Error::Error("Client stream manager closed".into()))??;
+            let res = await_channel_response(rx).await??;
             match res {
                 ApiStreamResponsePayload::Transaction(res) => res,
                 _ => unreachable!(),

--- a/hiqlite/src/network/api.rs
+++ b/hiqlite/src/network/api.rs
@@ -466,7 +466,7 @@ pub(crate) enum ApiStreamResponsePayload {
     KV(Result<CacheResponse, Error>),
 
     #[cfg(feature = "dlock")]
-    Lock(LockState),
+    Lock(Result<LockState, Error>),
 
     #[cfg(feature = "listen_notify_local")]
     Notify(Result<(), Error>),
@@ -817,7 +817,7 @@ async fn handle_socket_concurrent(
 
                     ApiStreamResponse {
                         request_id,
-                        result: ApiStreamResponsePayload::Lock(lock_state),
+                        result: ApiStreamResponsePayload::Lock(Ok(lock_state)),
                     }
                 }
 

--- a/hiqlite/src/network/management.rs
+++ b/hiqlite/src/network/management.rs
@@ -171,11 +171,11 @@ async fn are_we_leader(state: &AppStateExt, raft_type: &RaftType) -> Result<(), 
             Ok(())
         } else {
             let metrics = helpers::get_raft_metrics(state, raft_type).await;
-            let leader = metrics
-                .membership_config
-                .membership()
-                .get_node(&leader_id)
-                .expect("Leader ID to always exist in membership config");
+            let Some(leader) = metrics.membership_config.membership().get_node(&leader_id) else {
+                return Err(Error::Error(
+                    format!("Leader {leader_id} not found in membership config").into(),
+                ));
+            };
 
             let err = RaftError::APIError(CheckIsLeaderError::ForwardToLeader(ForwardToLeader {
                 leader_id: Some(leader_id),

--- a/hiqlite/src/network/raft_client.rs
+++ b/hiqlite/src/network/raft_client.rs
@@ -413,7 +413,15 @@ impl NetworkStreaming {
                 OpCode::Text => {}
                 OpCode::Binary => {
                     let bytes = frame.payload.deref();
-                    let payload = deserialize::<RaftStreamResponse>(bytes).unwrap();
+                    let payload = match deserialize::<RaftStreamResponse>(bytes) {
+                        Ok(payload) => payload,
+                        Err(err) => {
+                            // corrupt frame from a cluster member: drop the connection instead
+                            // of panicking the raft client task
+                            error!("Error deserializing raft response from member: {err:?}");
+                            break;
+                        }
+                    };
                     if let Err(err) = tx.send_async(RaftRequest::StreamResponse(payload)).await {
                         error!(
                             "Error sending Response to Raft client stream manager: {:?}",

--- a/hiqlite/src/network/raft_server.rs
+++ b/hiqlite/src/network/raft_server.rs
@@ -48,20 +48,6 @@ pub enum RaftStreamRequest {
     RemoveMembershipCache(u64),
 }
 
-impl From<&[u8]> for RaftStreamRequest {
-    #[inline]
-    fn from(value: &[u8]) -> Self {
-        deserialize(value).unwrap()
-    }
-}
-
-impl From<Vec<u8>> for RaftStreamRequest {
-    #[inline]
-    fn from(value: Vec<u8>) -> Self {
-        deserialize(&value).unwrap()
-    }
-}
-
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RaftStreamResponse {
     pub request_id: usize,
@@ -90,13 +76,6 @@ pub enum RaftStreamResponsePayload {
 pub(crate) enum WsWriteMsg {
     Payload(Vec<u8>),
     Break,
-}
-
-impl From<Vec<u8>> for RaftStreamResponse {
-    #[inline]
-    fn from(value: Vec<u8>) -> Self {
-        deserialize(&value).unwrap()
-    }
 }
 
 pub async fn stream_cache(

--- a/hiqlite/src/server/proxy/stream.rs
+++ b/hiqlite/src/server/proxy/stream.rs
@@ -239,19 +239,10 @@ pub async fn handle_socket(
                 }
 
                 ApiStreamRequestPayload::LockAwait(cache_req) => {
-                    match client.lock_req_retry(cache_req, true).await {
-                        Ok(res) => ApiStreamResponse {
-                            request_id,
-                            result: ApiStreamResponsePayload::Lock(res),
-                        },
-                        Err(_) => {
-                            todo!(
-                                "how should be handle await errors? wrap state inside inner result just for the proxy or retry endlessly?"
-                            )
-                        } // Err(err) => ApiStreamResponse {
-                          //     request_id,
-                          //     result: ApiStreamResponsePayload::Lock(Err(err)),
-                          // },
+                    let res = client.lock_req_retry(cache_req, true).await;
+                    ApiStreamResponse {
+                        request_id,
+                        result: ApiStreamResponsePayload::Lock(res),
                     }
                 }
 

--- a/hiqlite/src/server/proxy/stream.rs
+++ b/hiqlite/src/server/proxy/stream.rs
@@ -275,7 +275,9 @@ pub async fn handle_socket(
     let _ = tx_write.send_async(WsWriteMsg::Break).await;
     drop(tx_write);
 
-    handle_write.await.unwrap();
+    if let Err(err) = handle_write.await {
+        error!("Error joining proxy writer task: {err:?}");
+    }
 
     Ok(())
 }

--- a/hiqlite/src/store/state_machine/memory/dlock_handler.rs
+++ b/hiqlite/src/store/state_machine/memory/dlock_handler.rs
@@ -61,6 +61,13 @@ pub fn spawn() -> flume::Sender<LockRequest> {
 }
 
 async fn handler(rx: flume::Receiver<LockRequest>) {
+    // Lease timing (`exp`) intentionally uses this node's wall clock. All lock decisions are made
+    // by the Raft leader's handler, so they are always consistent with the leader's clock. The
+    // per-node `exp` copies in the state machine diverge by clock skew, but that is benign: Raft
+    // never verifies state machine equality, and the new leader evaluates leases with its own
+    // clock. A deterministic timestamp inside the raft entry would require changing the entry
+    // format, which would break log compatibility for rolling upgrades. Keep the clocks within
+    // ~1s of each other so a 10s lease survives failover comfortably.
     let mut locks: HashMap<String, LockQueue> = HashMap::new();
     let mut queues: HashMap<String, Vec<(u64, oneshot::Sender<LockState>)>> = HashMap::new();
 

--- a/hiqlite/src/store/state_machine/memory/dlock_handler.rs
+++ b/hiqlite/src/store/state_machine/memory/dlock_handler.rs
@@ -69,6 +69,24 @@ async fn handler(rx: flume::Receiver<LockRequest>) {
             LockRequest::Lock(LockRequestPayload { key, log_id, ack }) => {
                 let now = Utc::now().timestamp();
                 if let Some(lock) = locks.get_mut(key.as_ref()) {
+                    // If the lease of the current holder has expired, the holder is considered
+                    // dead. Any ticket at the front of the queue that had a full lease window to
+                    // reclaim the lock but did not is dead as well: drop it (and wake its client,
+                    // if it is still waiting) so it can never block the lock forever.
+                    if lock.exp < now {
+                        while let Some(&ticket) = lock.queue.front()
+                            && ticket != log_id
+                        {
+                            lock.queue.pop_front();
+                            if let Some(acks) = queues.get_mut(key.as_ref())
+                                && let Some(pos) = acks.iter().position(|(i, _)| *i == ticket)
+                            {
+                                let (_, ack) = acks.swap_remove(pos);
+                                let _ = ack.send(LockState::Released);
+                            }
+                        }
+                    }
+
                     if lock.exp < now || lock.current_ticket.is_none() {
                         let front = lock.queue.front();
                         if let Some(ticket) = front {
@@ -82,7 +100,6 @@ async fn handler(rx: flume::Receiver<LockRequest>) {
                                 ack.send(LockState::Queued(log_id)).unwrap();
                             }
                         } else {
-                            lock.queue.pop_front();
                             lock.current_ticket = Some(log_id);
                             lock.exp = now + LOCK_VALID_SECONDS;
                             ack.send(LockState::Locked(log_id)).unwrap();
@@ -106,24 +123,40 @@ async fn handler(rx: flume::Receiver<LockRequest>) {
 
             LockRequest::Acquire(LockRequestPayload { key, log_id, ack }) => {
                 if let Some(lock) = locks.get_mut(key.as_ref()) {
-                    debug_assert!(lock.current_ticket.is_none());
-                    debug_assert!(lock.queue.front().is_some());
-
-                    let first = lock
-                        .queue
-                        .pop_front()
-                        .expect("First entry to always exist for LockRequest::Acquire");
-                    debug_assert!(
-                        first == log_id,
-                        "first ({first}) and log_id ({log_id}) to always match when \
-                        LockRequest::Acquire"
-                    );
-
-                    lock.current_ticket = Some(first);
-                    lock.exp = Utc::now().timestamp() + LOCK_VALID_SECONDS;
-                    ack.send(LockState::Locked(log_id)).unwrap();
+                    if lock.current_ticket.is_some() {
+                        // Someone else holds the lock (e.g. our lease expired and the lock was
+                        // re-granted). Re-queue and report back so the client can wait again.
+                        lock.queue.push_back(log_id);
+                        ack.send(LockState::Queued(log_id)).unwrap();
+                    } else if let Some(first) = lock.queue.front() {
+                        if *first == log_id {
+                            lock.queue.pop_front();
+                            lock.current_ticket = Some(log_id);
+                            lock.exp = Utc::now().timestamp() + LOCK_VALID_SECONDS;
+                            ack.send(LockState::Locked(log_id)).unwrap();
+                        } else {
+                            // Our ticket is not the promoted one anymore -> re-queue.
+                            lock.queue.push_back(log_id);
+                            ack.send(LockState::Queued(log_id)).unwrap();
+                        }
+                    } else {
+                        // Nobody is queued and nobody holds the lock -> take it directly.
+                        lock.current_ticket = Some(log_id);
+                        lock.exp = Utc::now().timestamp() + LOCK_VALID_SECONDS;
+                        ack.send(LockState::Locked(log_id)).unwrap();
+                    }
                 } else {
-                    panic!("The lock should always exist when LockRequest::Acquire");
+                    // The lock was fully removed while this request was in flight. Grant a fresh
+                    // one so the client never hangs.
+                    locks.insert(
+                        key.to_string(),
+                        LockQueue {
+                            current_ticket: Some(log_id),
+                            exp: Utc::now().timestamp() + LOCK_VALID_SECONDS,
+                            queue: Default::default(),
+                        },
+                    );
+                    ack.send(LockState::Locked(log_id)).unwrap();
                 }
             }
 
@@ -141,7 +174,8 @@ async fn handler(rx: flume::Receiver<LockRequest>) {
                                     && let Err(err) =
                                         acks.swap_remove(pos).1.send(LockState::Released)
                                 {
-                                    panic!(
+                                    // The client may have disconnected - this is not fatal.
+                                    warn!(
                                         "Error sending lock await response for lock {key}: {err:?}"
                                     );
                                 }
@@ -150,8 +184,14 @@ async fn handler(rx: flume::Receiver<LockRequest>) {
                             full_remove = true;
                         }
                     } else {
-                        // TODO can this ever happen?
-                        panic!("Lock for {key} / {id} as been released already: {lock:?}");
+                        // The lease expired and the lock was granted to another ticket, or this
+                        // is a duplicate release. Releasing an already released / re-granted lock
+                        // is safe to ignore. Panicking here would kill the whole dlock handler.
+                        warn!(
+                            "Ignoring release for lock {key} / {id}: current holder is not this \
+                            ticket (current_ticket: {:?})",
+                            lock.current_ticket
+                        );
                     }
                 }
 
@@ -164,6 +204,21 @@ async fn handler(rx: flume::Receiver<LockRequest>) {
                 let now = Utc::now().timestamp();
 
                 if let Some(lock) = locks.get_mut(key.as_ref()) {
+                    // Same dead-ticket handling as in LockRequest::Lock.
+                    if lock.exp < now {
+                        while let Some(&ticket) = lock.queue.front()
+                            && ticket != id
+                        {
+                            lock.queue.pop_front();
+                            if let Some(acks) = queues.get_mut(key.as_ref())
+                                && let Some(pos) = acks.iter().position(|(i, _)| *i == ticket)
+                            {
+                                let (_, ack) = acks.swap_remove(pos);
+                                let _ = ack.send(LockState::Released);
+                            }
+                        }
+                    }
+
                     if lock.exp < now || lock.current_ticket.is_none() {
                         let front = lock.queue.front();
                         if let Some(ticket) = front {
@@ -178,10 +233,9 @@ async fn handler(rx: flume::Receiver<LockRequest>) {
                                 queues.insert(key.to_string(), vec![(id, ack)]);
                             }
                         } else {
-                            panic!(
-                                "for a LockAwait there must always be at least 1 element in \
-                                the queue when the current_ticket is None"
-                            );
+                            // Nothing to wait for: no current holder and no queued ticket. Let the
+                            // client re-request, it will get a fresh grant.
+                            ack.send(LockState::Released).unwrap();
                         }
                     } else if let Some(queue) = queues.get_mut(key.as_ref()) {
                         queue.push((id, ack));
@@ -189,7 +243,9 @@ async fn handler(rx: flume::Receiver<LockRequest>) {
                         queues.insert(key.to_string(), vec![(id, ack)]);
                     }
                 } else {
-                    panic!("The lock should always exist when we receive an await");
+                    // The lock was released and fully removed while this await was in flight.
+                    // Let the client re-request, it will get a fresh grant.
+                    ack.send(LockState::Released).unwrap();
                 }
             }
 

--- a/hiqlite/src/store/state_machine/memory/dlock_handler.rs
+++ b/hiqlite/src/store/state_machine/memory/dlock_handler.rs
@@ -40,7 +40,7 @@ pub struct LockAwaitPayload {
     pub ack: oneshot::Sender<LockState>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum LockState {
     Locked(u64),
     Queued(u64),
@@ -259,4 +259,129 @@ async fn handler(rx: flume::Receiver<LockRequest>) {
     }
 
     debug!("DLock handler exiting");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::borrow::Cow;
+    use tokio::sync::oneshot;
+
+    fn send(tx: &flume::Sender<LockRequest>, req: LockRequest) {
+        tx.send(req).expect("handler to be running");
+    }
+
+    async fn lock(tx: &flume::Sender<LockRequest>, key: &str, log_id: u64) -> LockState {
+        let (ack, rx) = oneshot::channel();
+        send(
+            tx,
+            LockRequest::Lock(LockRequestPayload {
+                key: Cow::Owned(key.to_string()),
+                log_id,
+                ack,
+            }),
+        );
+        rx.await.unwrap()
+    }
+
+    async fn acquire(tx: &flume::Sender<LockRequest>, key: &str, log_id: u64) -> LockState {
+        let (ack, rx) = oneshot::channel();
+        send(
+            tx,
+            LockRequest::Acquire(LockRequestPayload {
+                key: Cow::Owned(key.to_string()),
+                log_id,
+                ack,
+            }),
+        );
+        rx.await.unwrap()
+    }
+
+    async fn await_lock(tx: &flume::Sender<LockRequest>, key: &str, id: u64) -> LockState {
+        let (ack, rx) = oneshot::channel();
+        send(
+            tx,
+            LockRequest::Await(LockAwaitPayload {
+                key: Cow::Owned(key.to_string()),
+                id,
+                ack,
+            }),
+        );
+        rx.await.unwrap()
+    }
+
+    fn release(tx: &flume::Sender<LockRequest>, key: &str, id: u64) {
+        send(
+            tx,
+            LockRequest::Release(LockReleasePayload {
+                key: Cow::Owned(key.to_string()),
+                id,
+            }),
+        );
+    }
+
+    #[tokio::test]
+    async fn lock_release_roundtrip() {
+        let tx = spawn();
+        assert_eq!(lock(&tx, "k", 1).await, LockState::Locked(1));
+        assert_eq!(lock(&tx, "k", 2).await, LockState::Queued(2));
+        release(&tx, "k", 1);
+        // no current holder anymore: the queued ticket is granted directly while waiting
+        assert_eq!(await_lock(&tx, "k", 2).await, LockState::Locked(2));
+        release(&tx, "k", 2);
+    }
+
+    #[tokio::test]
+    async fn duplicate_release_is_ignored() {
+        let tx = spawn();
+        assert_eq!(lock(&tx, "k", 1).await, LockState::Locked(1));
+        release(&tx, "k", 1);
+        // second release of the same ticket must not panic the handler
+        release(&tx, "k", 1);
+        // handler is still alive
+        assert_eq!(lock(&tx, "k", 2).await, LockState::Locked(2));
+    }
+
+    #[tokio::test]
+    async fn release_after_lock_was_removed_is_ignored() {
+        let tx = spawn();
+        assert_eq!(lock(&tx, "k", 1).await, LockState::Locked(1));
+        release(&tx, "k", 1); // no waiters -> lock removed entirely
+        release(&tx, "k", 1); // stale release must be a no-op
+        assert_eq!(lock(&tx, "k", 2).await, LockState::Locked(2));
+    }
+
+    #[tokio::test]
+    async fn acquire_after_lock_was_removed_grants_fresh() {
+        let tx = spawn();
+        assert_eq!(lock(&tx, "k", 1).await, LockState::Locked(1));
+        release(&tx, "k", 1); // removed
+        // a client re-claiming with an old ticket must not hang or panic
+        assert_eq!(acquire(&tx, "k", 1).await, LockState::Locked(1));
+        release(&tx, "k", 1);
+    }
+
+    #[tokio::test]
+    async fn await_when_lock_was_removed_returns_released() {
+        let tx = spawn();
+        assert_eq!(lock(&tx, "k", 1).await, LockState::Locked(1));
+        release(&tx, "k", 1); // removed
+        // an in-flight await must be answered, not hang
+        assert_eq!(await_lock(&tx, "k", 1).await, LockState::Released);
+        assert_eq!(acquire(&tx, "k", 1).await, LockState::Locked(1));
+    }
+
+    #[tokio::test]
+    async fn late_release_after_takeover_is_ignored() {
+        let tx = spawn();
+        assert_eq!(lock(&tx, "k", 1).await, LockState::Locked(1));
+        release(&tx, "k", 1);
+        // lock is free again, ticket 2 takes it
+        assert_eq!(lock(&tx, "k", 2).await, LockState::Locked(2));
+        // the old holder (ticket 1) releases late -> must be ignored, not panic
+        release(&tx, "k", 1);
+        // ticket 2 still holds the lock and can release it normally
+        release(&tx, "k", 2);
+        assert_eq!(lock(&tx, "k", 3).await, LockState::Locked(3));
+    }
 }


### PR DESCRIPTION
## Summary

The distributed-lock subsystem (feature `dlock`) had several race conditions that could panic the lock handler — and with it every future lock on the node — or deadlock a lock key permanently:

- A lock holder slower than the 10 s lease caused an expiry takeover; the old holder's late `Drop` release then hit `panic!("... has been released already")`, killing the handler.
- A promoted waiter that died before re-acquiring left its ticket at the queue front forever; no new request could bypass it, so the lock key was blocked permanently.
- The client could orphan tickets by minting new ones on re-claim, and hit `unreachable!` when the handler granted a lock directly while it waited.

Related client/network hardening in the same area:

- Client requests now time out (120 s) instead of hanging forever on a stalled leader; a dead stream manager returns an error instead of panicking callers.
- The proxy relayed `LockAwait` failures into an `unimplemented!()` panic; the `Lock` response now carries the error and the client surfaces it.
- Corrupt frames from a cluster member drop the connection instead of panicking the raft client; dead panicking conversion impls were removed.

## Changes

- dlock handler: late/duplicate releases are ignored with a warning; awaits on removed locks are answered; acquire re-queues instead of asserting; stale queue-front tickets are drained once their lease window passes.
- dlock client: reuses its queue ticket across re-claims and accepts direct grants while waiting; lock waits are bounded by the request timeout.
- Client stream manager: 14 response awaits share a 120 s timeout helper; closed channels and stalls return errors.
- Proxy: `LockAwait` errors propagate through the response payload.
- Raft network: corrupt member frames drop the connection; dead `From` impls removed; leader-membership lookup errors instead of panicking.

## Verification

- `cargo test -p hiqlite --lib --features full` — 31 passed, including 6 lock handler tests (protocol roundtrip, duplicate/late release, removal races) and 3 timeout-helper tests.
- `TEST_SKIP_S3_RESTORE=true cargo test --features cache,counters,dlock,listen_notify,macros,toml` (CI matrix, lib+bins) — 31 passed; `cargo test -p hiqlite-wal` — 7 passed.
- `cargo clippy -p hiqlite --features full -- -D warnings` — clean.

## Compatibility notes

Lock lease semantics are unchanged (leader wall clock, 10 s lease); the deterministic-timestamp alternative requires a breaking raft entry format change and is intentionally left as a documented design decision. The proxy `Lock` response payload changes shape (now `Result`) — client and server ship in the same version.

Developed with carefully directed, manually reviewed AI assistance.