### PR TITLE
fix(dashboard): Throttle login attempts per client

### DIFF
--- a/hiqlite/src/dashboard/session.rs
+++ b/hiqlite/src/dashboard/session.rs
@@ -12,8 +12,10 @@ use chrono::Utc;
 use cryptr::EncValue;
 use cryptr::utils::{b64_decode, b64_encode};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::env;
-use std::sync::LazyLock;
+use std::sync::{LazyLock, Mutex, OnceLock};
+use std::time::{Duration, Instant};
 use tracing::debug;
 
 const COOKIE_NAME: &str = "__Host-Hiqlite-Session";
@@ -26,6 +28,103 @@ pub static INSECURE_COOKIES: LazyLock<bool> = LazyLock::new(|| {
         .parse::<bool>()
         .expect("Cannot parse HQL_INSECURE_COOKIE as bool")
 });
+
+// Login brute-force protection. The frontend PoW is currently disabled (the embedded Svelte 5
+// build cannot load the spow WASM), so login throttling is the active protection: after a few
+// failed attempts per client, further attempts are rejected with 429 for a lockout window.
+// Combined with the global single-flight lock in `password::verify_password`, this caps both
+// the per-client rate and the overall parallel attempt throughput.
+const MAX_LOGIN_FAILURES: u8 = 5;
+const LOGIN_LOCKOUT: Duration = Duration::from_secs(60);
+const MAX_TRACKED_CLIENTS: usize = 10_000;
+
+#[derive(Debug, Default)]
+struct LoginThrottle {
+    failures: HashMap<String, (u8, Instant)>,
+}
+
+impl LoginThrottle {
+    fn is_locked(&self, key: &str, now: Instant) -> bool {
+        if let Some((count, since)) = self.failures.get(key) {
+            *count >= MAX_LOGIN_FAILURES && now.duration_since(*since) < LOGIN_LOCKOUT
+        } else {
+            false
+        }
+    }
+
+    fn record_failure(&mut self, key: &str, now: Instant) {
+        if self.failures.len() >= MAX_TRACKED_CLIENTS {
+            // avoid unbounded growth from many distinct spoofed client ids
+            self.failures.clear();
+        }
+        // a lockout that already expired must not carry its count over, otherwise the very
+        // next failure would re-lock the client forever
+        let expired = self
+            .failures
+            .get(key)
+            .map(|(_, since)| now.duration_since(*since) >= LOGIN_LOCKOUT)
+            .unwrap_or(false);
+        if expired {
+            self.failures.remove(key);
+        }
+        let (count, since) = self.failures.entry(key.to_string()).or_insert((0, now));
+        *count += 1;
+        *since = now;
+    }
+
+    fn clear(&mut self, key: &str) {
+        self.failures.remove(key);
+    }
+}
+
+static LOGIN_THROTTLE: OnceLock<Mutex<LoginThrottle>> = OnceLock::new();
+
+fn login_throttle() -> &'static Mutex<LoginThrottle> {
+    LOGIN_THROTTLE.get_or_init(|| Mutex::new(LoginThrottle::default()))
+}
+
+/// Best-effort client key. Uses the rightmost `X-Forwarded-For` entry (the hop added by the
+/// closest proxy). `None` when the header is absent: those clients cannot be told apart, so
+/// they are not throttled per-client.
+fn client_key(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get("x-forwarded-for")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|v| v.rsplit(',').next())
+        .map(|addr| addr.trim().to_string())
+        .filter(|addr| !addr.is_empty())
+}
+
+fn check_login_throttle(headers: &HeaderMap) -> Result<(), Error> {
+    let Some(key) = client_key(headers) else {
+        // no client id available: a shared bucket would let one attacker lock out everyone
+        // without a proxy header. the global single-flight lock in password::verify_password
+        // still caps the overall attempt throughput.
+        return Ok(());
+    };
+    let throttle = login_throttle().lock().unwrap_or_else(|e| e.into_inner());
+    if throttle.is_locked(&key, Instant::now()) {
+        Err(Error::RateLimit(
+            "too many failed login attempts, try again later".into(),
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn record_login_failure(headers: &HeaderMap) {
+    if let Some(key) = client_key(headers) {
+        let mut throttle = login_throttle().lock().unwrap_or_else(|e| e.into_inner());
+        throttle.record_failure(&key, Instant::now());
+    }
+}
+
+fn clear_login_failures(headers: &HeaderMap) {
+    if let Some(key) = client_key(headers) {
+        let mut throttle = login_throttle().lock().unwrap_or_else(|e| e.into_inner());
+        throttle.clear(&key);
+    }
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct Session {
@@ -76,7 +175,9 @@ impl Session {
         let cookie_header = if *INSECURE_COOKIES {
             format!("{COOKIE_NAME_DEV}={b64}; HttpOnly; SameSite=Lax; Max-Age={max_age}")
         } else {
-            format!("{COOKIE_NAME}={b64}; Secure; HttpOnly; SameSite=Lax; Max-Age={max_age}; Path=/")
+            format!(
+                "{COOKIE_NAME}={b64}; Secure; HttpOnly; SameSite=Lax; Max-Age={max_age}; Path=/"
+            )
         };
 
         Ok(cookie_header)
@@ -125,8 +226,14 @@ pub async fn set_session_verify(
     password: String,
 ) -> Result<Response, Error> {
     check_csrf(&method, headers).await?;
+    // reject locked-out clients before spending argon2 time on them
+    check_login_throttle(headers)?;
     if let Some(pwd) = state.dashboard.password_dashboard.clone() {
-        password::verify_password(password, pwd).await?;
+        if let Err(err) = password::verify_password(password, pwd).await {
+            record_login_failure(headers);
+            return Err(err);
+        }
+        clear_login_failures(headers);
 
         let session = Session::new();
         let cookie = session.as_cookie()?;
@@ -185,5 +292,81 @@ async fn check_csrf(method: &Method, headers: &HeaderMap) -> Result<(), Error> {
         } else {
             Err(Error::Unauthorized("CSRF violation".into()))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(i: u64) -> String {
+        format!("10.0.0.{i}")
+    }
+
+    #[test]
+    fn throttle_locks_after_max_failures_and_expires() {
+        let mut throttle = LoginThrottle::default();
+        let t0 = Instant::now();
+
+        for i in 0..MAX_LOGIN_FAILURES - 1 {
+            assert!(!throttle.is_locked(&key(1), t0));
+            throttle.record_failure(&key(1), t0);
+        }
+        // one below the limit is still allowed
+        assert!(!throttle.is_locked(&key(1), t0));
+
+        throttle.record_failure(&key(1), t0);
+        assert!(throttle.is_locked(&key(1), t0));
+        // other clients are unaffected
+        assert!(!throttle.is_locked(&key(2), t0));
+
+        // lockout expires after the window
+        let t1 = t0 + LOGIN_LOCKOUT + Duration::from_secs(1);
+        assert!(!throttle.is_locked(&key(1), t1));
+    }
+
+    #[test]
+    fn successful_login_clears_failures() {
+        let mut throttle = LoginThrottle::default();
+        let t0 = Instant::now();
+        throttle.record_failure(&key(1), t0);
+        throttle.record_failure(&key(1), t0);
+        throttle.clear(&key(1));
+        assert!(!throttle.is_locked(&key(1), t0));
+    }
+
+    #[test]
+    fn throttle_map_is_bounded() {
+        let mut throttle = LoginThrottle::default();
+        let t0 = Instant::now();
+        for i in 0..MAX_TRACKED_CLIENTS + 5 {
+            throttle.record_failure(&key(i as u64), t0);
+        }
+        assert!(throttle.failures.len() <= MAX_TRACKED_CLIENTS);
+    }
+
+    #[test]
+    fn client_key_uses_rightmost_xff_hop() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "1.2.3.4, 5.6.7.8".parse().unwrap());
+        assert_eq!(client_key(&headers), Some("5.6.7.8".to_string()));
+        assert_eq!(client_key(&HeaderMap::new()), None);
+    }
+
+    #[test]
+    fn lockout_expiry_resets_the_counter() {
+        let mut throttle = LoginThrottle::default();
+        let t0 = Instant::now();
+        for _ in 0..MAX_LOGIN_FAILURES {
+            throttle.record_failure(&key(1), t0);
+        }
+        assert!(throttle.is_locked(&key(1), t0));
+
+        // after the lockout window the client is allowed again, and the very next failure
+        // must not re-lock immediately (fresh counter)
+        let t1 = t0 + LOGIN_LOCKOUT + Duration::from_secs(1);
+        assert!(!throttle.is_locked(&key(1), t1));
+        throttle.record_failure(&key(1), t1);
+        assert!(!throttle.is_locked(&key(1), t1));
     }
 }


### PR DESCRIPTION
## Summary

The dashboard login proof-of-work is currently disabled: loading the spow WASM in the embedded Svelte 5 build failed during the framework's preview era (sveltejs/svelte#13155, closed without a fix; TODO in `Login.svelte`). Re-enabling it is tracked separately as `feat/dashboard-pow-reenable` — the import now builds, hydrates and computes on the stable stack (Svelte 5.56.8 / Vite 8.2 / SvelteKit 2.70.2), but the server-side `Pow::validate` and the secure-context (TLS) requirement noted in `handlers.rs` are addressed there, not here. With PoW gone, the login endpoint was freely brute-forceable; the only protection was a global single-flight lock on password verification, which caps parallelism but not the total attempt rate.

This change adds per-client failed-login throttling as the active protection.

## Changes

- Failed logins are tracked per client, keyed by the rightmost `X-Forwarded-For` hop (the entry added by the closest proxy).
- After 5 failures the client is locked out with `429 Too Many Requests` for 60 seconds; the check runs before password verification so locked-out clients do not consume argon2 work.
- A lockout expiry resets the counter, so a legitimate user is never locked forever by a single extra failure.
- Clients without a proxy header share no bucket — a spoofed or missing header cannot be used to lock everyone out.
- Successful login clears the failure counter.
- The existing global single-flight lock in password verification remains as the throughput backstop.

## Verification

- `cargo test -p hiqlite --lib --features full` — 36 passed, including 5 new login-throttle unit tests (lock after max failures, expiry reset, clear on success, bounded map, rightmost-header keying).
- `cargo clippy -p hiqlite --features full -- -D warnings` — clean.

## Compatibility notes

The PoW challenge endpoint and the frontend PoW plumbing stay in place; the throttle is the active protection. The WASM-loading blocker from the Svelte 5 preview era is gone — verified on Svelte 5.56.8 / Vite 8.2 / SvelteKit 2.70.2: the spow import builds, hydrates, and `pow_work_wasm` computes a proof in the browser. Re-enabling PoW (`feat/dashboard-pow-reenable`) re-activates `Pow::validate` in `post_session` (the spow secret is already initialized from the configured encryption key at startup) and serves the dashboard over TLS via `tls_api` / `tls_auto_certificates` for the secure context.

Developed with carefully directed, manually reviewed AI assistance.