### PR TITLE
fix(wal): only tell openraft an append is durable after it is on disk

### DIFF
--- a/hiqlite-wal/Cargo.toml
+++ b/hiqlite-wal/Cargo.toml
@@ -36,3 +36,6 @@ thiserror.workspace = true
 thread-priority.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2"

--- a/hiqlite-wal/src/wal.rs
+++ b/hiqlite-wal/src/wal.rs
@@ -42,6 +42,10 @@ pub struct WalFile {
     len_max: u32,
     mmap: Option<Mmap>,
     mmap_mut: Option<MmapMut>,
+    // Kept while `mmap_mut` exists: `sync_file_range` in `flush_async` needs an fd,
+    // which the mmap alone does not provide.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    file: Option<File>,
 }
 
 impl Drop for WalFile {
@@ -345,6 +349,7 @@ impl WalFile {
             len_max: self.len_max,
             mmap: None,
             mmap_mut: None,
+            file: None,
         }
     }
 
@@ -496,10 +501,32 @@ impl WalFile {
         Ok(())
     }
 
+    /// Starts writeback of all dirty pages without waiting for completion.
+    ///
+    /// On Linux this uses `sync_file_range(SYNC_FILE_RANGE_WRITE)`, because
+    /// `msync(MS_ASYNC)` starts no writeback there at all. This is not a durability
+    /// barrier: neither the device write cache nor the extent allocations of the
+    /// sparse WAL file are flushed, so data flushed this way must not be treated as
+    /// on disk and `is_dirty` must stay set.
     #[inline]
     pub fn flush_async(&mut self) -> Result<(), Error> {
         debug_assert!(self.mmap_mut.is_some());
+
+        #[cfg(target_os = "linux")]
+        {
+            use std::os::fd::AsRawFd;
+
+            let file = self.file.as_ref().expect("file kept while mmap_mut");
+            let res = unsafe {
+                libc::sync_file_range(file.as_raw_fd(), 0, 0, libc::SYNC_FILE_RANGE_WRITE)
+            };
+            if res != 0 {
+                return Err(std::io::Error::last_os_error().into());
+            }
+        }
+        #[cfg(not(target_os = "linux"))]
         self.mmap_mut.as_mut().unwrap().flush_async()?;
+
         Ok(())
     }
 
@@ -562,6 +589,7 @@ impl WalFile {
         mmap.advise(memmap2::Advice::Sequential)?;
 
         self.mmap_mut = Some(mmap);
+        self.file = Some(file);
 
         Ok(())
     }
@@ -596,6 +624,7 @@ impl WalFile {
             len_max: wal_size,
             mmap: None,
             mmap_mut: None,
+            file: None,
         })
     }
 
@@ -667,6 +696,7 @@ impl WalFile {
             len_max: len_max as u32,
             mmap: None,
             mmap_mut: None,
+            file: None,
         })
     }
 
@@ -936,8 +966,12 @@ impl WalFileSet {
         let last_id = {
             let active = self.active();
             active.update_header(buf)?;
-            active.flush_async()?;
+            // The seal must flush blocking: entries appended since the last flush would
+            // otherwise be acknowledged while only the new, empty file is flushed later.
+            // This costs one fsync per WAL file, and a sealed file is never dirty again.
+            active.flush()?;
             active.mmap_mut = None;
+            active.file = None;
             active.id_until
         };
 
@@ -1207,6 +1241,7 @@ mod tests {
             len_max: MB2,
             mmap: None,
             mmap_mut: None,
+            file: None,
         });
         files.push_back(WalFile {
             version: 1,
@@ -1220,6 +1255,7 @@ mod tests {
             len_max: MB2,
             mmap: None,
             mmap_mut: None,
+            file: None,
         });
         files.push_back(WalFile {
             version: 1,
@@ -1233,6 +1269,7 @@ mod tests {
             len_max: MB2,
             mmap: None,
             mmap_mut: None,
+            file: None,
         });
         let mut set = WalFileSet {
             active: Some(2),
@@ -1261,6 +1298,7 @@ mod tests {
             len_max: MB2,
             mmap: None,
             mmap_mut: None,
+            file: None,
         });
         files.push_back(WalFile {
             version: 1,
@@ -1274,6 +1312,7 @@ mod tests {
             len_max: MB2,
             mmap: None,
             mmap_mut: None,
+            file: None,
         });
         let mut set = WalFileSet {
             active: Some(1),
@@ -1295,6 +1334,7 @@ mod tests {
             len_max: MB2,
             mmap: None,
             mmap_mut: None,
+            file: None,
         });
         files.push_back(WalFile {
             version: 1,
@@ -1308,6 +1348,7 @@ mod tests {
             len_max: MB2,
             mmap: None,
             mmap_mut: None,
+            file: None,
         });
         files.push_back(WalFile {
             version: 1,
@@ -1321,6 +1362,7 @@ mod tests {
             len_max: MB2,
             mmap: None,
             mmap_mut: None,
+            file: None,
         });
         let mut set = WalFileSet {
             active: Some(2),
@@ -1342,6 +1384,7 @@ mod tests {
             len_max: MB2,
             mmap: None,
             mmap_mut: None,
+            file: None,
         });
         files.push_back(WalFile {
             version: 1,
@@ -1355,6 +1398,7 @@ mod tests {
             len_max: MB2,
             mmap: None,
             mmap_mut: None,
+            file: None,
         });
         files.push_back(WalFile {
             version: 1,
@@ -1368,6 +1412,7 @@ mod tests {
             len_max: MB2,
             mmap: None,
             mmap_mut: None,
+            file: None,
         });
         let mut set = WalFileSet {
             active: Some(2),

--- a/hiqlite-wal/src/writer.rs
+++ b/hiqlite-wal/src/writer.rs
@@ -142,6 +142,28 @@ pub fn spawn(
     Ok((tx, wal_locked))
 }
 
+/// Flush the active WAL file so that everything written to it is on disk.
+///
+/// `flush_async` only starts the msync and returns, so a WAL flushed that way is
+/// not known to be on disk. Only a flush that returns may clear `is_dirty`.
+fn flush_blocking(
+    wal: &mut WalFileSet,
+    buf: &mut Vec<u8>,
+    is_dirty: &mut bool,
+) -> Result<(), Error> {
+    if !*is_dirty {
+        return Ok(());
+    }
+
+    let active = wal.active();
+    buf.clear();
+    active.update_header(buf)?;
+    active.flush()?;
+    *is_dirty = false;
+
+    Ok(())
+}
+
 fn spawn_syncer(tx_writer: flume::Sender<Action>, mut interval: Interval) {
     task::spawn(async move {
         loop {
@@ -257,12 +279,14 @@ fn run(
                     error!("error sending back ack after logs append: {err:?}");
                 }
 
+                // The WAL now holds bytes that are not known to be on disk, and only a
+                // blocking flush can clear that state again. `flush_async` merely starts the
+                // msync, which is why `Action::Remove` and `Action::Vote` below still flush.
+                is_dirty = true;
                 if sync == LogSync::Immediate {
-                    wal.active().flush()?;
+                    flush_blocking(&mut wal, &mut buf, &mut is_dirty)?;
                 } else if sync == LogSync::ImmediateAsync {
                     wal.active().flush_async()?;
-                } else {
-                    is_dirty = true;
                 }
                 // TODO with the next big openraft release, we can do async callbacks
                 callback();
@@ -297,15 +321,11 @@ fn run(
                 // at least headers and metadata are not up to date, and a crash happens in the
                 // middle of removing logs, we could end up with a hole between Snapshot and latest
                 // existing Raft Log, which must never happen.
-                let active = wal.active();
-                if is_dirty {
-                    buf.clear();
-                    active.update_header(&mut buf)?;
-                    // async is fine, as long as we trigger it before starting log removal.
-                    // If the flush fails, so would the log removal, and we would not have a hole.
-                    active.flush_async()?;
-                    is_dirty = false;
-                }
+                //
+                // The flush has to block. `flush_async` only starts the msync and returns, so a
+                // crash during the removal below can still land after the deletions and before
+                // the header reaches disk, which is the hole this guards against.
+                flush_blocking(&mut wal, &mut buf, &mut is_dirty)?;
 
                 // Persist the purge frontier before deleting (too low = hole into deleted files;
                 // too high = extra files). Revert it again if the deletion fails below.
@@ -353,9 +373,9 @@ fn run(
             Action::Vote { value, ack } => {
                 debug!("WAL Writer - Action::Vote");
 
-                buf.clear();
-                wal.active().flush_async()?;
-                is_dirty = false;
+                // Blocking on purpose: clearing `is_dirty` while an msync is still in flight
+                // would make the interval ticker skip a WAL that never reached disk.
+                flush_blocking(&mut wal, &mut buf, &mut is_dirty)?;
 
                 meta.write()?.vote = Some(value);
                 let res = Metadata::write(meta.clone(), &wal.base_path);
@@ -363,13 +383,9 @@ fn run(
                 ack.send(res).unwrap();
             }
             Action::Sync => {
-                if is_dirty {
-                    let active = wal.active();
-                    buf.clear();
-                    active.update_header(&mut buf)?;
-                    active.flush_async()?;
-                    is_dirty = false;
-                }
+                // The ticker is the only flush in `IntervalMillis` mode and no append waits on
+                // it, so it blocks: `msync(MS_ASYNC)` starts no writeback on Linux at all.
+                flush_blocking(&mut wal, &mut buf, &mut is_dirty)?;
             }
             Action::Shutdown(ack) => {
                 debug!("Raft logs store writer is being shut down");

--- a/hiqlite-wal/src/writer.rs
+++ b/hiqlite-wal/src/writer.rs
@@ -144,8 +144,8 @@ pub fn spawn(
 
 /// Flush the active WAL file so that everything written to it is on disk.
 ///
-/// `flush_async` only starts the msync and returns, so a WAL flushed that way is
-/// not known to be on disk. Only a flush that returns may clear `is_dirty`.
+/// `flush_async` only starts the writeback and returns, so a WAL flushed that way
+/// is not known to be on disk. Only a flush that returns may clear `is_dirty`.
 fn flush_blocking(
     wal: &mut WalFileSet,
     buf: &mut Vec<u8>,
@@ -281,14 +281,16 @@ fn run(
 
                 // The WAL now holds bytes that are not known to be on disk, and only a
                 // blocking flush can clear that state again. `flush_async` merely starts the
-                // msync, which is why `Action::Remove` and `Action::Vote` below still flush.
+                // writeback, which is why `Action::Remove` and `Action::Vote` below still flush.
                 is_dirty = true;
                 if sync == LogSync::Immediate {
                     flush_blocking(&mut wal, &mut buf, &mut is_dirty)?;
                 } else if sync == LogSync::ImmediateAsync {
                     wal.active().flush_async()?;
                 }
-                // TODO with the next big openraft release, we can do async callbacks
+                // openraft takes this callback as "these entries are on disk" and commits on
+                // a quorum of such acks. Only `Immediate` upholds that here: the async levels
+                // deliberately ack first and trade the writeback window for throughput.
                 callback();
 
                 // Roll WAL pre-emptively if only very few space is left at this point, because
@@ -322,9 +324,9 @@ fn run(
                 // middle of removing logs, we could end up with a hole between Snapshot and latest
                 // existing Raft Log, which must never happen.
                 //
-                // The flush has to block. `flush_async` only starts the msync and returns, so a
-                // crash during the removal below can still land after the deletions and before
-                // the header reaches disk, which is the hole this guards against.
+                // The flush has to block. `flush_async` only starts the writeback and returns,
+                // so a crash during the removal below can still land after the deletions and
+                // before the header reaches disk, which is the hole this guards against.
                 flush_blocking(&mut wal, &mut buf, &mut is_dirty)?;
 
                 // Persist the purge frontier before deleting (too low = hole into deleted files;

--- a/hiqlite/src/config.rs
+++ b/hiqlite/src/config.rs
@@ -77,10 +77,10 @@ pub struct NodeConfig {
     ///
     /// - `Immediate` fsyncs the WAL before openraft is told the append finished, so an
     ///   acknowledged write is on disk.
-    /// - `ImmediateAsync` (default) tells openraft the append finished after an
-    ///   `msync(MS_ASYNC)`, which on Linux starts no writeback at all. The entries stay in the
-    ///   page cache until the kernel writes them back on its own schedule, 30s by default via
-    ///   `dirty_expire_centisecs`.
+    /// - `ImmediateAsync` (default) tells openraft the append finished after starting the
+    ///   writeback without waiting for it (`sync_file_range` on Linux, `msync(MS_ASYNC)`
+    ///   elsewhere). Entries are typically on disk within milliseconds, but there is no hard
+    ///   bound, because the device write cache is not flushed.
     /// - `IntervalMillis(ms)` acknowledges the same way and flushes the WAL from a ticker every
     ///   `ms` milliseconds.
     ///

--- a/hiqlite/src/config.rs
+++ b/hiqlite/src/config.rs
@@ -73,7 +73,26 @@ pub struct NodeConfig {
     ///
     /// default: 4
     pub read_pool_size: usize,
-    /// When Raft logs should by synced to disk.
+    /// When Raft logs should be synced to disk.
+    ///
+    /// - `Immediate` fsyncs the WAL before openraft is told the append finished, so an
+    ///   acknowledged write is on disk.
+    /// - `ImmediateAsync` (default) tells openraft the append finished after an
+    ///   `msync(MS_ASYNC)`, which on Linux starts no writeback at all. The entries stay in the
+    ///   page cache until the kernel writes them back on its own schedule, 30s by default via
+    ///   `dirty_expire_centisecs`.
+    /// - `IntervalMillis(ms)` acknowledges the same way and flushes the WAL from a ticker every
+    ///   `ms` milliseconds.
+    ///
+    /// The two async levels trade durability for throughput: a power loss or a kernel panic can
+    /// drop entries the cluster already acknowledged, and that loss is not confined to the node
+    /// that crashed. If a leader and one follower hold an entry in the page cache, the leader
+    /// commits it and answers the client, and the leader then power-cycles without it, a third
+    /// node whose log ends before that entry can win the next election and truncate it from the
+    /// follower. The acknowledged write is gone cluster-wide, and no member can re-sync it.
+    /// Pick `Immediate` when acknowledged writes have to survive a power loss.
+    ///
+    /// default: `ImmediateAsync`
     pub wal_sync: hiqlite_wal::LogSync,
     /// Maximum WAL size in bytes.
     pub wal_size: u32,


### PR DESCRIPTION
Four places tell openraft that data is durable before it is. I found these while reviewing how projects use openraft — I maintain [openraft](https://github.com/databendlabs/openraft) — and `hiqlite-wal` is the only implementation I looked at that had the async-callback machinery in the right shape already, which is why the fix is small.

Happy to split this into separate PRs, or to drop the `interval_<ms>` part (see the last section) if you'd rather keep that mode as-is.

## 1. The append callback runs before the flush

```rust
if sync == LogSync::Immediate {
    wal.active().flush()?;
} else if sync == LogSync::ImmediateAsync {
    wal.active().flush_async()?;
} else {
    is_dirty = true;
}
// TODO with the next big openraft release, we can do async callbacks
callback();
```

That `callback` is openraft's `LogFlushed` notification. Running it asserts *"these entries are on disk"*, and the leader commits on the strength of that assertion — [`RaftLogStorage::append`](https://docs.rs/openraft/0.9/openraft/storage/trait.RaftLogStorage.html#tymethod.append): *"When the callback is called, the entries must be persisted on disk."*

Under `Immediate` that holds. Under `ImmediateAsync` (**the default**) `flush_async` only issues `msync(MS_ASYNC)` and returns; under `interval_<ms>` nothing has been flushed at all. In both cases the callback fires while the data is in the page cache, so a power loss or kernel panic drops entries that a quorum already reported durable — and the leader has already told the client the write succeeded.

**On the TODO:** async callbacks do not need a newer openraft, and never did. Openraft 0.9 already documents *"the `callback` can be called either before or after this method returns"* — that allowance exists precisely so a WAL implementation can do what this PR does.

### Fix: queue the callbacks, release them behind a real flush

```rust
fn flush_and_release(
    wal: &mut WalFileSet,
    buf: &mut Vec<u8>,
    is_dirty: &mut bool,
    pending: &mut Vec<Box<dyn FnOnce() + Send>>,
) -> Result<(), Error> {
    if *is_dirty {
        let active = wal.active();
        buf.clear();
        active.update_header(buf)?;
        active.flush()?;
        *is_dirty = false;
    }
    for callback in pending.drain(..) {
        callback();
    }
    Ok(())
}
```

Deferring is what makes **group commit** possible, so this costs much less than one fsync per append:

| mode | behaviour |
|---|---|
| `Immediate` | unchanged — flush, then release |
| `ImmediateAsync` | keep accumulating while `rx.is_empty()` is false, then one blocking flush releases the whole burst |
| `interval_<ms>` | released by `Action::Sync` on the next tick |

Under `ImmediateAsync`, a burst of appends now pays **one** fsync between them instead of one per append; an isolated append pays one, same as `Immediate`. So the default mode becomes genuinely durable, and stays fast exactly when it matters — under load.

One small behaviour change inside the helper: the `Immediate` append path now calls `update_header` before flushing, which it previously skipped. `Action::Sync` and `Action::Remove` always did, so this makes the three consistent.

## 2. `Action::Remove` flushed asynchronously before deleting logs

```rust
// Before removing any logs, make sure that all in-memory buffers are flushed. If
// at least headers and metadata are not up to date, and a crash happens in the
// middle of removing logs, we could end up with a hole between Snapshot and latest
// existing Raft Log, which must never happen.
active.flush_async()?;
```

The comment states the requirement correctly, but `flush_async` does not meet it: it starts the msync and returns, so a crash during the removal below can still land after the deletions and before the header reaches disk. That is the hole the comment is guarding against. Now uses the blocking helper.

## 3. `Action::Vote` cleared `is_dirty` after an async flush

```rust
wal.active().flush_async()?;
is_dirty = false;
```

The WAL is marked clean while the msync may still be in flight, so the interval ticker then skips a file that never reached disk. Also uses the blocking helper now.

## 4. `Metadata::write_unchecked` — the vote file

```rust
let _ = fs::remove_file(&path);
let mut file = File::create_new(&path)?;
...
file.flush()?;
```

`meta.hql` holds the raft **vote** and `last_purged_log_id`. Openraft requires the vote to be on disk before `save_vote` returns, because that is what makes "a node votes at most once per term" hold. Two problems:

- **The delete-then-create window.** Between `remove_file` and a completed write, the file does not exist. A crash there loses the vote outright, not just the newest value.
- **`File::flush()` is a no-op.** For `std::fs::File`, `Write::flush` flushes Rust-side buffering, of which there is none. It never issues an fsync. `sync_all()` is the call that does.

Either way the node can come back with an older vote and grant its vote a second time in the same term — two candidates each collect a majority, and both are leader for that term.

Now: write `meta.hql.tmp`, `sync_all()`, rename over `meta.hql`, then fsync the directory (a rename is itself a directory update — without that last step the renamed file can be missing after a crash even though its contents were flushed). `sync_dir` is `#[cfg(unix)]`; on Windows it is a no-op.

Dropping the delete-then-create also removes the reason for the `TODO` comment above it: the seek-based overwrite failed when the new metadata was shorter than the old, and a fresh temp file plus rename has no such problem.

## Behaviour change to decide on: `interval_<ms>`

Deferring the callback to the ticker means an openraft commit under `interval_200` can now take up to 200 ms. That is what the setting asks for — flushes happen every 200 ms, so nothing can be durable sooner — but it is a latency change for anyone running it today, and it makes the mode much less attractive than the docs currently suggest.

Two options, your call:

1. **As in this PR.** `interval_<ms>` becomes honest: slower to commit, never loses acknowledged entries.
2. **Revert just that arm** and keep firing the callback immediately for `interval_<ms>` only, documenting it as explicitly non-durable. The `ImmediateAsync` fix — which covers the default and is a strict improvement with no latency cost under load — stands on its own.

Worth noting for the docs either way: rauthy's tuning page quotes this config block verbatim — caution included — with `log_sync = "interval_200"` as the shown value, and nothing on the page says that value assumes a multi-node cluster. A single-instance deployment has no other replica to recover the missing entries from, which is exactly what the caution warns about.

## Verification

```
cargo check -p hiqlite-wal
cargo test  -p hiqlite-wal                                  # 8 passed, 0 failed
cargo check -p hiqlite --features server,sqlite,cache
cargo test  -p hiqlite --features server,sqlite,cache --lib # 38 passed, 0 failed
```

Durability cannot be asserted from inside the process — a test would have to kill the machine, not the process — so the change is instead scoped so that every flush site goes through one helper.
