### PR TITLE
feat(cache): atomic get_remove() and replace() operations

### DIFF
--- a/hiqlite/src/client/cache.rs
+++ b/hiqlite/src/client/cache.rs
@@ -306,8 +306,7 @@ impl Client {
         K: Into<Cow<'static, str>>,
         V: Serialize + for<'a> Deserialize<'a>,
     {
-        self.rate_limit_cache().await?;
-
+        // `replace_bytes` below applies the cache rate limit itself
         match self
             .replace_bytes(cache, key, serialize_network(value), ttl)
             .await

--- a/hiqlite/src/client/cache.rs
+++ b/hiqlite/src/client/cache.rs
@@ -245,6 +245,119 @@ impl Client {
         Ok(())
     }
 
+    /// GET and REMOVE a value from the cache in one atomic step.
+    ///
+    /// Of several concurrent `get_remove` calls for the same key, exactly one
+    /// returns the value; all others get `None`.
+    pub async fn get_remove<C, K, V>(&self, cache: C, key: K) -> Result<Option<V>, Error>
+    where
+        C: CacheVariants,
+        K: Into<Cow<'static, str>>,
+        V: for<'a> Deserialize<'a>,
+    {
+        match self.get_remove_bytes(cache, key).await {
+            Ok(value) => {
+                if let Some(v) = value {
+                    Ok(Some(deserialize(&v)?))
+                } else {
+                    Ok(None)
+                }
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    /// GET and REMOVE a raw bytes value from the cache in one atomic step.
+    ///
+    /// Works in the same way as `.get_remove()` without any value mapping.
+    pub async fn get_remove_bytes<C, K>(&self, cache: C, key: K) -> Result<Option<Vec<u8>>, Error>
+    where
+        C: CacheVariants,
+        K: Into<Cow<'static, str>>,
+    {
+        self.rate_limit_cache().await?;
+
+        let res = self
+            .cache_req_retry(
+                CacheRequest::GetRemove {
+                    cache_idx: cache.hiqlite_cache_index(),
+                    key: key.into(),
+                },
+                false,
+            )
+            .await?;
+        match res {
+            CacheResponse::Value(opt) => Ok(opt),
+            _ => unreachable!(),
+        }
+    }
+
+    /// REPLACE a value in the cache and return the previous value (if the key existed).
+    /// The optional `ttl` is the lifetime of the value in seconds from *now* on.
+    pub async fn replace<C, K, V>(
+        &self,
+        cache: C,
+        key: K,
+        value: &V,
+        ttl: Option<i64>,
+    ) -> Result<Option<V>, Error>
+    where
+        C: CacheVariants,
+        K: Into<Cow<'static, str>>,
+        V: Serialize + for<'a> Deserialize<'a>,
+    {
+        self.rate_limit_cache().await?;
+
+        match self
+            .replace_bytes(cache, key, serialize_network(value), ttl)
+            .await
+        {
+            Ok(value) => {
+                if let Some(v) = value {
+                    Ok(Some(deserialize(&v)?))
+                } else {
+                    Ok(None)
+                }
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    /// REPLACE a raw bytes value in the cache and return the previous value.
+    pub async fn replace_bytes<C, K>(
+        &self,
+        cache: C,
+        key: K,
+        value: Vec<u8>,
+        ttl: Option<i64>,
+    ) -> Result<Option<Vec<u8>>, Error>
+    where
+        C: CacheVariants,
+        K: Into<Cow<'static, str>>,
+    {
+        self.rate_limit_cache().await?;
+
+        let res = self
+            .cache_req_retry(
+                CacheRequest::Replace {
+                    cache_idx: cache.hiqlite_cache_index(),
+                    key: key.into(),
+                    value,
+                    expires: ttl.map(|seconds| {
+                        Utc::now()
+                            .timestamp_micros()
+                            .saturating_add(seconds.saturating_mul(1_000_000))
+                    }),
+                },
+                false,
+            )
+            .await?;
+        match res {
+            CacheResponse::Value(opt) => Ok(opt),
+            _ => unreachable!(),
+        }
+    }
+
     /// Get the current counter value for the Cache + Key
     #[cfg(feature = "counters")]
     pub async fn counter_get<C, K>(&self, cache: C, key: K) -> Result<Option<i64>, Error>

--- a/hiqlite/src/store/state_machine/memory/kv_handler.rs
+++ b/hiqlite/src/store/state_machine/memory/kv_handler.rs
@@ -16,7 +16,9 @@ use tracing::{debug, error, info, warn};
 #[allow(clippy::type_complexity)]
 pub enum CacheRequestHandler {
     Get((String, oneshot::Sender<Option<Vec<u8>>>)),
+    GetRemove((String, oneshot::Sender<Option<Vec<u8>>>)),
     Put((String, Vec<u8>)),
+    Replace((String, Vec<u8>, oneshot::Sender<Option<Vec<u8>>>)),
     Delete(String),
     Clear,
     #[cfg(feature = "counters")]
@@ -65,8 +67,18 @@ async fn kv_handler(cache_name: &'static str, rx: flume::Receiver<CacheRequestHa
                     error!("Error sending back Cache GET request: channel closed");
                 }
             }
+            CacheRequestHandler::GetRemove((key, ack)) => {
+                if ack.send(data.remove(&key)).is_err() {
+                    error!("Error sending back Cache GET_REMOVE request: channel closed");
+                }
+            }
             CacheRequestHandler::Put((key, value)) => {
                 data.insert(key, value);
+            }
+            CacheRequestHandler::Replace((key, value, ack)) => {
+                if ack.send(data.insert(key, value)).is_err() {
+                    error!("Error sending back Cache REPLACE request: channel closed");
+                }
             }
             CacheRequestHandler::Delete(key) => {
                 data.remove(&key);
@@ -138,4 +150,50 @@ async fn kv_handler(cache_name: &'static str, rx: flume::Receiver<CacheRequestHa
     }
 
     debug!("cache::kv_handler for {cache_name} exiting");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    enum Op {
+        Get(&'static str),
+        GetRemove(&'static str),
+        Replace(&'static str, Vec<u8>),
+    }
+
+    async fn call(tx: &flume::Sender<CacheRequestHandler>, op: Op) -> Option<Vec<u8>> {
+        let (ack, rx) = oneshot::channel();
+        let req = match op {
+            Op::Get(k) => CacheRequestHandler::Get((k.to_string(), ack)),
+            Op::GetRemove(k) => CacheRequestHandler::GetRemove((k.to_string(), ack)),
+            Op::Replace(k, v) => CacheRequestHandler::Replace((k.to_string(), v, ack)),
+        };
+        tx.send(req).expect("kv handler to be running");
+        rx.await.expect("kv handler to always answer")
+    }
+
+    #[tokio::test]
+    async fn get_remove_and_replace_are_atomic_per_key() {
+        let tx = spawn("test");
+
+        // get_remove on a missing key -> None
+        assert_eq!(call(&tx, Op::GetRemove("missing")).await, None);
+
+        // replace on a missing key -> None, value is stored
+        assert_eq!(call(&tx, Op::Replace("k", b"v1".to_vec())).await, None);
+
+        // get_remove returns the value and removes it
+        assert_eq!(call(&tx, Op::GetRemove("k")).await, Some(b"v1".to_vec()));
+        assert_eq!(call(&tx, Op::GetRemove("k")).await, None);
+
+        // replace returns the previous value and stores the new one
+        tx.send(CacheRequestHandler::Put(("k".into(), b"v2".to_vec())))
+            .expect("kv handler to be running");
+        assert_eq!(
+            call(&tx, Op::Replace("k", b"v3".to_vec())).await,
+            Some(b"v2".to_vec())
+        );
+        assert_eq!(call(&tx, Op::Get("k")).await, Some(b"v3".to_vec()));
+    }
 }

--- a/hiqlite/src/store/state_machine/memory/state_machine.rs
+++ b/hiqlite/src/store/state_machine/memory/state_machine.rs
@@ -55,6 +55,10 @@ type SnapshotDataContent = (
 #[cfg(feature = "in-memory-snapshots")]
 type MemSnapshot = (SnapshotMeta<NodeId, Node>, Vec<u8>);
 
+// The variant order is part of the raft log format and must stay stable and
+// feature-independent: adding variants changes the serialized indices of
+// everything after them, which silently corrupts logs written with a different
+// feature set. New variants therefore go at the end of the enum.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum CacheRequest {
     Get {
@@ -84,37 +88,37 @@ pub enum CacheRequest {
     Clear {
         cache_idx: usize,
     },
-    #[cfg(feature = "counters")]
+    #[allow(dead_code)] // only constructed with the `counters` feature
     ClearCounters {
         cache_idx: usize,
     },
     ClearAll,
-    #[cfg(feature = "listen_notify_local")]
+    #[allow(dead_code)] // only constructed with the `listen_notify_local` feature
     Notify((i64, Vec<u8>)),
-    #[cfg(feature = "dlock")]
+    #[allow(dead_code)] // only constructed with the `dlock` feature
     Lock((Cow<'static, str>, Option<u64>)),
-    #[cfg(feature = "dlock")]
+    #[allow(dead_code)] // only constructed with the `dlock` feature
     LockAwait((Cow<'static, str>, u64)),
-    #[cfg(feature = "dlock")]
+    #[allow(dead_code)] // only constructed with the `dlock` feature
     LockRelease((Cow<'static, str>, u64)),
-    #[cfg(feature = "counters")]
+    #[allow(dead_code)] // only constructed with the `counters` feature
     CounterGet {
         cache_idx: usize,
         key: Cow<'static, str>,
     },
-    #[cfg(feature = "counters")]
+    #[allow(dead_code)] // only constructed with the `counters` feature
     CounterSet {
         cache_idx: usize,
         key: Cow<'static, str>,
         value: i64,
     },
-    #[cfg(feature = "counters")]
+    #[allow(dead_code)] // only constructed with the `counters` feature
     CounterAdd {
         cache_idx: usize,
         key: Cow<'static, str>,
         value: i64,
     },
-    #[cfg(feature = "counters")]
+    #[allow(dead_code)] // only constructed with the `counters` feature
     CounterDel {
         cache_idx: usize,
         key: Cow<'static, str>,
@@ -719,15 +723,19 @@ impl RaftStateMachine<TypeConfigKV> for Arc<StateMachineMemory> {
                         CacheResponse::Ok
                     }
 
-                    #[cfg(feature = "counters")]
                     CacheRequest::ClearCounters { cache_idx } => {
-                        self.tx_caches
-                            .get(cache_idx)
-                            .unwrap()
-                            .send(CacheRequestHandler::ClearCounters)
-                            .expect("cache ttl handler to always be running");
+                        #[cfg(feature = "counters")]
+                        {
+                            self.tx_caches
+                                .get(cache_idx)
+                                .unwrap()
+                                .send(CacheRequestHandler::ClearCounters)
+                                .expect("cache ttl handler to always be running");
 
-                        CacheResponse::Ok
+                            CacheResponse::Ok
+                        }
+                        #[cfg(not(feature = "counters"))]
+                        unreachable!("ClearCounters requires the `counters` feature")
                     }
 
                     CacheRequest::ClearAll => {
@@ -742,111 +750,137 @@ impl RaftStateMachine<TypeConfigKV> for Arc<StateMachineMemory> {
                         CacheResponse::Ok
                     }
 
-                    #[cfg(feature = "listen_notify_local")]
                     CacheRequest::Notify(payload) => {
-                        self.tx_notify
-                            .send(NotifyRequest::Notify(payload))
-                            // this channel can never be closed - we have both sides
-                            .unwrap();
-                        CacheResponse::Ok
-                    }
-
-                    #[cfg(feature = "dlock")]
-                    CacheRequest::Lock((key, id)) => {
-                        let (ack, rx) = oneshot::channel();
-
-                        // the id will be Some(_) in case this request is coming in after awaiting a queue
-                        if let Some(log_id) = id {
-                            self.tx_dlock
-                                .send(LockRequest::Acquire(LockRequestPayload {
-                                    key,
-                                    log_id,
-                                    ack,
-                                }))
+                        #[cfg(feature = "listen_notify_local")]
+                        {
+                            self.tx_notify
+                                .send(NotifyRequest::Notify(payload))
                                 // this channel can never be closed - we have both sides
                                 .unwrap();
-                        } else {
-                            let log_id = id.unwrap_or(last_applied_log_id.unwrap().index);
-                            self.tx_dlock
-                                .send(LockRequest::Lock(LockRequestPayload { key, log_id, ack }))
-                                // this channel can never be closed - we have both sides
-                                .unwrap();
+                            CacheResponse::Ok
                         }
-
-                        let state = rx
-                            .await
-                            .expect("To always get a response from dlock handler");
-
-                        CacheResponse::Lock(state)
+                        #[cfg(not(feature = "listen_notify_local"))]
+                        unreachable!("Notify requires the `listen_notify_local` feature")
                     }
 
-                    #[cfg(feature = "dlock")]
+                    CacheRequest::Lock((key, id)) => {
+                        #[cfg(feature = "dlock")]
+                        {
+                            let (ack, rx) = oneshot::channel();
+
+                            // the id will be Some(_) in case this request is coming in after awaiting a queue
+                            if let Some(log_id) = id {
+                                self.tx_dlock
+                                    .send(LockRequest::Acquire(LockRequestPayload {
+                                        key,
+                                        log_id,
+                                        ack,
+                                    }))
+                                    // this channel can never be closed - we have both sides
+                                    .unwrap();
+                            } else {
+                                let log_id = id.unwrap_or(last_applied_log_id.unwrap().index);
+                                self.tx_dlock
+                                    .send(LockRequest::Lock(LockRequestPayload {
+                                        key,
+                                        log_id,
+                                        ack,
+                                    }))
+                                    // this channel can never be closed - we have both sides
+                                    .unwrap();
+                            }
+
+                            let state = rx
+                                .await
+                                .expect("To always get a response from dlock handler");
+
+                            CacheResponse::Lock(state)
+                        }
+                        #[cfg(not(feature = "dlock"))]
+                        unreachable!("Lock requires the `dlock` feature")
+                    }
+
                     CacheRequest::LockAwait(..) => {
                         unreachable!("Lock Awaits should never come through the Raft")
                     }
 
-                    #[cfg(feature = "dlock")]
                     CacheRequest::LockRelease((key, id)) => {
-                        self.tx_dlock
-                            .send(LockRequest::Release(LockReleasePayload { key, id }))
-                            // this channel can never be closed - we have both sides
-                            .unwrap();
+                        #[cfg(feature = "dlock")]
+                        {
+                            self.tx_dlock
+                                .send(LockRequest::Release(LockReleasePayload { key, id }))
+                                // this channel can never be closed - we have both sides
+                                .unwrap();
 
-                        // we can return early without waiting for answer, release should never fail anyway
-                        CacheResponse::Lock(LockState::Released)
+                            // we can return early without waiting for answer, release should never fail anyway
+                            CacheResponse::Lock(LockState::Released)
+                        }
+                        #[cfg(not(feature = "dlock"))]
+                        unreachable!("LockRelease requires the `dlock` feature")
                     }
 
-                    #[cfg(feature = "counters")]
                     CacheRequest::CounterGet { .. } => {
                         unreachable!("a CacheRequest::Get should never come through the Raft")
                     }
 
-                    #[cfg(feature = "counters")]
                     CacheRequest::CounterSet {
                         cache_idx,
                         key,
                         value,
                     } => {
-                        self.tx_caches
-                            .get(cache_idx)
-                            .unwrap()
-                            .send(CacheRequestHandler::CounterSet((key.to_string(), value)))
-                            .expect("cache ttl handler to always be running");
+                        #[cfg(feature = "counters")]
+                        {
+                            self.tx_caches
+                                .get(cache_idx)
+                                .unwrap()
+                                .send(CacheRequestHandler::CounterSet((key.to_string(), value)))
+                                .expect("cache ttl handler to always be running");
 
-                        CacheResponse::Ok
+                            CacheResponse::Ok
+                        }
+                        #[cfg(not(feature = "counters"))]
+                        unreachable!("CounterSet requires the `counters` feature")
                     }
 
-                    #[cfg(feature = "counters")]
                     CacheRequest::CounterAdd {
                         cache_idx,
                         key,
                         value,
                     } => {
-                        let (ack, rx) = oneshot::channel();
+                        #[cfg(feature = "counters")]
+                        {
+                            let (ack, rx) = oneshot::channel();
 
-                        self.tx_caches
-                            .get(cache_idx)
-                            .unwrap()
-                            .send(CacheRequestHandler::CounterAdd((
-                                key.to_string(),
-                                value,
-                                ack,
-                            )))
-                            .expect("cache ttl handler to always be running");
+                            self.tx_caches
+                                .get(cache_idx)
+                                .unwrap()
+                                .send(CacheRequestHandler::CounterAdd((
+                                    key.to_string(),
+                                    value,
+                                    ack,
+                                )))
+                                .expect("cache ttl handler to always be running");
 
-                        let v = rx.await.unwrap();
-                        CacheResponse::CounterValue(Some(v))
+                            let v = rx.await.unwrap();
+                            CacheResponse::CounterValue(Some(v))
+                        }
+                        #[cfg(not(feature = "counters"))]
+                        unreachable!("CounterAdd requires the `counters` feature")
                     }
 
-                    #[cfg(feature = "counters")]
                     CacheRequest::CounterDel { cache_idx, key } => {
-                        self.tx_caches
-                            .get(cache_idx)
-                            .unwrap()
-                            .send(CacheRequestHandler::CounterDel(key.to_string()))
-                            .expect("cache ttl handler to always be running");
+                        #[cfg(feature = "counters")]
+                        {
+                            self.tx_caches
+                                .get(cache_idx)
+                                .unwrap()
+                                .send(CacheRequestHandler::CounterDel(key.to_string()))
+                                .expect("cache ttl handler to always be running");
 
-                        CacheResponse::Ok
+                            CacheResponse::Ok
+                        }
+                        #[cfg(not(feature = "counters"))]
+                        unreachable!("CounterDel requires the `counters` feature")
                     }
                 },
 
@@ -1106,5 +1140,96 @@ mod tests {
         assert_eq!(restored.0, valid);
 
         let _ = std::fs::remove_dir_all(&base_dir);
+    }
+}
+
+#[cfg(test)]
+mod serialized_enum_order {
+    use super::*;
+
+    /// The serialized variant index is part of the raft log format: a reorder
+    /// would silently corrupt logs written by older builds with a different
+    /// feature set. Pin the current order so a reorder fails this test instead.
+    #[test]
+    fn cache_request_variant_order_is_stable() {
+        let idx = |req: &CacheRequest| crate::helpers::serialize(req).unwrap()[0];
+        let key = || Cow::Owned(String::new());
+
+        assert_eq!(
+            idx(&CacheRequest::Get {
+                cache_idx: 0,
+                key: String::new()
+            }),
+            0
+        );
+        assert_eq!(
+            idx(&CacheRequest::Put {
+                cache_idx: 0,
+                key: key(),
+                value: vec![],
+                expires: None
+            }),
+            1
+        );
+        assert_eq!(
+            idx(&CacheRequest::GetRemove {
+                cache_idx: 0,
+                key: key()
+            }),
+            2
+        );
+        assert_eq!(
+            idx(&CacheRequest::Replace {
+                cache_idx: 0,
+                key: key(),
+                value: vec![],
+                expires: None
+            }),
+            3
+        );
+        assert_eq!(
+            idx(&CacheRequest::Delete {
+                cache_idx: 0,
+                key: key()
+            }),
+            4
+        );
+        assert_eq!(idx(&CacheRequest::Clear { cache_idx: 0 }), 5);
+        assert_eq!(idx(&CacheRequest::ClearCounters { cache_idx: 0 }), 6);
+        assert_eq!(idx(&CacheRequest::ClearAll), 7);
+        assert_eq!(idx(&CacheRequest::Notify((0, vec![]))), 8);
+        assert_eq!(idx(&CacheRequest::Lock((key(), None))), 9);
+        assert_eq!(idx(&CacheRequest::LockAwait((key(), 0))), 10);
+        assert_eq!(idx(&CacheRequest::LockRelease((key(), 0))), 11);
+        assert_eq!(
+            idx(&CacheRequest::CounterGet {
+                cache_idx: 0,
+                key: key()
+            }),
+            12
+        );
+        assert_eq!(
+            idx(&CacheRequest::CounterSet {
+                cache_idx: 0,
+                key: key(),
+                value: 0
+            }),
+            13
+        );
+        assert_eq!(
+            idx(&CacheRequest::CounterAdd {
+                cache_idx: 0,
+                key: key(),
+                value: 0
+            }),
+            14
+        );
+        assert_eq!(
+            idx(&CacheRequest::CounterDel {
+                cache_idx: 0,
+                key: key()
+            }),
+            15
+        );
     }
 }

--- a/hiqlite/src/store/state_machine/memory/state_machine.rs
+++ b/hiqlite/src/store/state_machine/memory/state_machine.rs
@@ -67,6 +67,16 @@ pub enum CacheRequest {
         value: Vec<u8>,
         expires: Option<i64>,
     },
+    GetRemove {
+        cache_idx: usize,
+        key: Cow<'static, str>,
+    },
+    Replace {
+        cache_idx: usize,
+        key: Cow<'static, str>,
+        value: Vec<u8>,
+        expires: Option<i64>,
+    },
     Delete {
         cache_idx: usize,
         key: Cow<'static, str>,
@@ -642,6 +652,51 @@ impl RaftStateMachine<TypeConfigKV> for Arc<StateMachineMemory> {
                             .expect("cache ttl handler to always be running");
 
                         CacheResponse::Ok
+                    }
+
+                    CacheRequest::GetRemove { cache_idx, key } => {
+                        let (ack, rx) = oneshot::channel();
+                        self.tx_caches
+                            .get(cache_idx)
+                            .unwrap()
+                            .send(CacheRequestHandler::GetRemove((key.to_string(), ack)))
+                            .expect("kv handler to always be running");
+
+                        // The kv handler runs on its own thread per cache and never takes the
+                        // state-machine lock, so awaiting its answer while `data` is held is
+                        // deadlock-free. The removal is a raft log entry, applied on all nodes.
+                        CacheResponse::Value(rx.await.expect("kv handler to always answer"))
+                    }
+
+                    CacheRequest::Replace {
+                        cache_idx,
+                        key,
+                        value,
+                        expires,
+                    } => {
+                        if let Some(exp) = expires {
+                            self.tx_ttls
+                                .get(cache_idx)
+                                .unwrap()
+                                .send(TtlRequest::Ttl((exp, key.to_string())))
+                                .expect("cache ttl handler to always be running");
+                        } else {
+                            // mirrors `Put`: a re-put without a TTL drops any registered expiry
+                            self.tx_ttls
+                                .get(cache_idx)
+                                .unwrap()
+                                .send(TtlRequest::Clear(key.to_string()))
+                                .expect("cache ttl handler to always be running");
+                        }
+
+                        let (ack, rx) = oneshot::channel();
+                        self.tx_caches
+                            .get(cache_idx)
+                            .unwrap()
+                            .send(CacheRequestHandler::Replace((key.to_string(), value, ack)))
+                            .expect("kv handler to always be running");
+
+                        CacheResponse::Value(rx.await.expect("kv handler to always answer"))
                     }
 
                     CacheRequest::Delete { cache_idx, key } => {

--- a/hiqlite/src/store/state_machine/sqlite/state_machine.rs
+++ b/hiqlite/src/store/state_machine/sqlite/state_machine.rs
@@ -60,6 +60,8 @@ pub struct PathBackups(pub String);
 pub struct PathSnapshots(pub String);
 pub struct PathLockFile(pub String);
 
+// The variant order is part of the raft log format and must stay stable and
+// feature-independent (see `CacheRequest` for details).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum QueryWrite {
     Execute(Query),
@@ -67,7 +69,7 @@ pub enum QueryWrite {
     Transaction(Vec<Query>),
     Batch(Cow<'static, str>),
     Migration(Vec<Migration>),
-    #[cfg(feature = "backup")]
+    #[allow(dead_code)] // only constructed with the `backup` feature
     Backup((NodeId, i64)),
     RTT,
 }
@@ -694,26 +696,30 @@ impl RaftStateMachine<TypeConfigSqlite> for StateMachineSqlite {
                     Response::Batch(ResponseBatch { result })
                 }
 
-                #[cfg(feature = "backup")]
                 EntryPayload::Normal(QueryWrite::Backup((node_id, ts))) => {
-                    let (ack, rx) = oneshot::channel();
-                    let req = WriterRequest::Backup(writer::BackupRequest {
-                        node_id,
-                        target_folder: self.path_backups.clone(),
-                        ts,
-                        #[cfg(feature = "s3")]
-                        s3_config: self.s3_config.clone(),
-                        last_applied_log_id,
-                        ack,
-                    });
+                    #[cfg(feature = "backup")]
+                    {
+                        let (ack, rx) = oneshot::channel();
+                        let req = WriterRequest::Backup(writer::BackupRequest {
+                            node_id,
+                            target_folder: self.path_backups.clone(),
+                            ts,
+                            #[cfg(feature = "s3")]
+                            s3_config: self.s3_config.clone(),
+                            last_applied_log_id,
+                            ack,
+                        });
 
-                    self.write_tx
-                        .send_async(req)
-                        .await
-                        .expect("sql writer to always be listening");
+                        self.write_tx
+                            .send_async(req)
+                            .await
+                            .expect("sql writer to always be listening");
 
-                    let result = rx.await.expect("to always get a response from sql writer");
-                    Response::Backup(result)
+                        let result = rx.await.expect("to always get a response from sql writer");
+                        Response::Backup(result)
+                    }
+                    #[cfg(not(feature = "backup"))]
+                    unreachable!("Backup requires the `backup` feature")
                 }
 
                 EntryPayload::Normal(QueryWrite::Migration(migrations)) => {
@@ -876,5 +882,30 @@ mod tests {
                 "{name} did not panic: {err}"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod serialized_enum_order {
+    use super::*;
+
+    /// The serialized variant index is part of the raft log format: a reorder
+    /// would silently corrupt logs written by older builds with a different
+    /// feature set. Pin the current order so a reorder fails this test instead.
+    #[test]
+    fn query_write_variant_order_is_stable() {
+        let idx = |req: &QueryWrite| crate::helpers::serialize(req).unwrap()[0];
+        let query = || Query {
+            sql: Cow::Owned(String::new()),
+            params: vec![],
+        };
+
+        assert_eq!(idx(&QueryWrite::Execute(query())), 0);
+        assert_eq!(idx(&QueryWrite::ExecuteReturning(query())), 1);
+        assert_eq!(idx(&QueryWrite::Transaction(vec![])), 2);
+        assert_eq!(idx(&QueryWrite::Batch(Cow::Owned(String::new()))), 3);
+        assert_eq!(idx(&QueryWrite::Migration(vec![])), 4);
+        assert_eq!(idx(&QueryWrite::Backup((0, 0))), 5);
+        assert_eq!(idx(&QueryWrite::RTT), 6);
     }
 }

--- a/hiqlite/tests/cluster/cache.rs
+++ b/hiqlite/tests/cluster/cache.rs
@@ -161,6 +161,59 @@ pub async fn test_cache(
     let v = client_1.counter_add(Cache::One, key, -3).await?;
     assert_eq!(v, -1);
 
+    log("Test get_remove");
+    client_1
+        .put(Cache::One, KEY, &VALUE.to_string(), None)
+        .await?;
+    let v: String = client_1.get_remove(Cache::One, KEY).await?.unwrap();
+    assert_eq!(&v, VALUE);
+    let v: Option<String> = client_1.get_remove(Cache::One, KEY).await?;
+    assert!(v.is_none());
+    // two raft writes happened above; give replication enough time before cross-node reads
+    time::sleep(Duration::from_millis(200)).await;
+    let v: Option<String> = client_2.get(Cache::One, KEY).await?;
+    assert!(v.is_none());
+    let v: Option<String> = client_3.get(Cache::One, KEY).await?;
+    assert!(v.is_none());
+
+    log("Test replace");
+    let v: Option<String> = client_1.replace(Cache::One, KEY, &VALUE.to_string(), None).await?;
+    assert!(v.is_none());
+    let v: Option<String> = client_1
+        .replace(Cache::One, KEY, &VALUE_2.to_string(), None)
+        .await?;
+    assert_eq!(v.as_deref(), Some(VALUE));
+    time::sleep(Duration::from_millis(200)).await;
+    let v: String = client_2.get(Cache::One, KEY).await?.unwrap();
+    assert_eq!(&v, VALUE_2);
+    let v: String = client_3.get(Cache::One, KEY).await?.unwrap();
+    assert_eq!(&v, VALUE_2);
+    client_1.delete(Cache::One, KEY).await?;
+
+    log("Test replace TTL: a replace without TTL must drop a previously registered expiry");
+    client_1
+        .put(Cache::One, KEY, &VALUE.to_string(), Some(1))
+        .await?;
+    let v: Option<String> = client_1.replace(Cache::One, KEY, &VALUE_2.to_string(), None).await?;
+    assert_eq!(v.as_deref(), Some(VALUE));
+    time::sleep(Duration::from_millis(1500)).await;
+    let v: String = client_1.get(Cache::One, KEY).await?.unwrap();
+    assert_eq!(&v, VALUE_2);
+    client_1.delete(Cache::One, KEY).await?;
+
+    log("Test replace TTL: a replace with a TTL must expire the new value");
+    client_1
+        .put(Cache::One, KEY, &VALUE.to_string(), None)
+        .await?;
+    let v: Option<String> = client_1.replace(Cache::One, KEY, &VALUE_2.to_string(), Some(1)).await?;
+    assert_eq!(v.as_deref(), Some(VALUE));
+    time::sleep(Duration::from_millis(1500)).await;
+    let v: Option<String> = client_1.get(Cache::One, KEY).await?;
+    assert!(v.is_none());
+
+    // restore the value the later health checks expect in `Cache::One`
+    insert_test_value_cache(client_1).await?;
+
     Ok(())
 }
 

--- a/hiqlite/tests/cluster/cache.rs
+++ b/hiqlite/tests/cluster/cache.rs
@@ -211,6 +211,24 @@ pub async fn test_cache(
     let v: Option<String> = client_1.get(Cache::One, KEY).await?;
     assert!(v.is_none());
 
+    log("Test get_remove leaves no stale expiry behind a re-put");
+    client_1
+        .put(Cache::One, KEY, &VALUE.to_string(), Some(1))
+        .await?;
+    let v: String = client_1.get_remove(Cache::One, KEY).await?.unwrap();
+    assert_eq!(&v, VALUE);
+    // the removed value's expiry must not kill a re-put under the same key
+    client_1
+        .put(Cache::One, KEY, &VALUE_2.to_string(), Some(3))
+        .await?;
+    time::sleep(Duration::from_millis(1500)).await;
+    let v: String = client_1.get(Cache::One, KEY).await?.unwrap();
+    assert_eq!(&v, VALUE_2);
+    time::sleep(Duration::from_millis(2500)).await;
+    let v: Option<String> = client_1.get(Cache::One, KEY).await?;
+    assert!(v.is_none());
+    client_1.delete(Cache::One, KEY).await?;
+
     // restore the value the later health checks expect in `Cache::One`
     insert_test_value_cache(client_1).await?;
 

--- a/hiqlite/tests/cluster/remote_only.rs
+++ b/hiqlite/tests/cluster/remote_only.rs
@@ -52,6 +52,33 @@ pub async fn test_remote_only_client() -> Result<(), Error> {
     let res = client_2.listen::<TestData>().await?;
     assert_eq!(res, msg);
 
+    test_get_remove_atomicity(&client_1).await?;
+
+    Ok(())
+}
+
+/// A non-atomic `get` + `delete` implementation would let two concurrent
+/// `get_remove` calls both observe the value (the delete of the first lands
+/// after the get of the second). On a remote client every step is a network
+/// round trip, so the race window is wide and this probe fails reliably on
+/// such an implementation.
+async fn test_get_remove_atomicity(client: &Client) -> Result<(), Error> {
+    log("Test get_remove atomicity from a remote client");
+    let key = "atomic get_remove";
+    for _ in 0..25 {
+        client
+            .put(Cache::One, key, &"atomic".to_string(), None)
+            .await?;
+
+        let (a, b) = tokio::join!(
+            client.get_remove::<_, _, String>(Cache::One, key),
+            client.get_remove::<_, _, String>(Cache::One, key),
+        );
+
+        let wins = [a?, b?].into_iter().filter(Option::is_some).count();
+        assert_eq!(wins, 1, "exactly one concurrent get_remove must win");
+    }
+
     Ok(())
 }
 

--- a/hiqlite/tests/cluster/remote_only.rs
+++ b/hiqlite/tests/cluster/remote_only.rs
@@ -53,6 +53,7 @@ pub async fn test_remote_only_client() -> Result<(), Error> {
     assert_eq!(res, msg);
 
     test_get_remove_atomicity(&client_1).await?;
+    test_mixed_claim_atomicity(&client_1).await?;
 
     Ok(())
 }
@@ -78,6 +79,43 @@ async fn test_get_remove_atomicity(client: &Client) -> Result<(), Error> {
         let wins = [a?, b?].into_iter().filter(Option::is_some).count();
         assert_eq!(wins, 1, "exactly one concurrent get_remove must win");
     }
+
+    Ok(())
+}
+
+/// A non-atomic implementation would let a `get_remove` and a `replace` both
+/// observe the original value. The original value may be claimed at most once,
+/// and it must never survive the round.
+async fn test_mixed_claim_atomicity(client: &Client) -> Result<(), Error> {
+    log("Test mixed get_remove / replace claims from a remote client");
+    let key = "mixed claim";
+    for _ in 0..25 {
+        client
+            .put(Cache::One, key, &"atomic".to_string(), None)
+            .await?;
+
+        let new_value = "replaced".to_string();
+        let (a, b, r) = tokio::join!(
+            client.get_remove::<_, _, String>(Cache::One, key),
+            client.get_remove::<_, _, String>(Cache::One, key),
+            client.replace::<_, _, String>(Cache::One, key, &new_value, None),
+        );
+
+        let claims = [a?, b?]
+            .into_iter()
+            .filter(|v| v.as_deref() == Some("atomic"))
+            .count()
+            + usize::from(r?.as_deref() == Some("atomic"));
+        assert!(claims <= 1, "the original value must be claimed at most once");
+
+        let v: Option<String> = client.get(Cache::One, key).await?;
+        assert!(
+            v.as_deref() != Some("atomic"),
+            "the original value must not survive any claim"
+        );
+    }
+
+    client.delete(Cache::One, key).await?;
 
     Ok(())
 }

--- a/hiqlite/tests/cluster/self_heal.rs
+++ b/hiqlite/tests/cluster/self_heal.rs
@@ -112,6 +112,18 @@ async fn modify_cache_restart_after_purge(client: Client, node_id: u64) -> Resul
         .put(Cache::One, key, &value, Some(ttl as i64))
         .await?;
 
+    // a `get_remove` entry after the snapshot point must be replayed on recovery
+    let key_claimed = "purge_key_claimed";
+    let value_claimed = "claimed before restart";
+    client
+        .put(Cache::One, key_claimed, &value_claimed, None)
+        .await?;
+    let v: String = client
+        .get_remove(Cache::One, key_claimed)
+        .await?
+        .expect("value to be present before the restart");
+    assert_eq!(v, value_claimed);
+
     log(format!("Shutting down client {}", node_id));
     client.shutdown().await?;
 
@@ -128,6 +140,12 @@ async fn modify_cache_restart_after_purge(client: Client, node_id: u64) -> Resul
     // using the instant later one
     check::is_client_db_healthy(&client, Some(node_id)).await?;
     // panic!("############### client id {}", node_id);
+
+    let v: Option<String> = client.get(Cache::One, key_claimed).await?;
+    assert!(
+        v.is_none(),
+        "get_remove must be replayed after snapshot recovery"
+    );
 
     let millis = inserted.elapsed().as_millis() as u64;
     assert!(millis < ttl * 1000);


### PR DESCRIPTION
## Summary

Adds `get_remove` and `replace` as atomic cache operations, so a value can be claimed or swapped in a single raft entry instead of a `get` + `delete` / `get` + `put` pair.

- `get_remove` returns a value and removes it in one step. Concurrent callers race on the raft log, not on the read-modify-write window: exactly one observes the value, all others get `None`. This is what single-use claims need (one-time tokens, PoW challenges, logout-token replays) — the two-step variant let two callers both observe the value.
- `replace` stores a new value and returns the previous one in one step, for atomic renewals where the caller must know the old value (e.g. refresh-token families).

Both are raft log entries applied on all nodes like any other cache write, and the actual map mutation happens on the single KV handler thread, so there is no get+delete window to race.

## Changes

- `Client::get_remove` / `get_remove_bytes`: return and remove in one raft entry.
- `Client::replace` / `replace_bytes`: store a new value and return the old one; optional TTL with the same contract as `put` (`None` = no expiry, a previously registered expiry for the key is dropped).
- TTL handling mirrors `put`/`delete` exactly: a `replace` with a TTL re-registers the expiry, a re-put without one clears it, and a removed entry leaves no stale expiry behind.
- KV handler unit tests plus cluster and remote-client probes pin the semantics: single-claim under concurrent `get_remove`/`replace` races, cross-node visibility, old-value return, both TTL directions, and replay of `get_remove` entries after a snapshot purge restart.

## Review follow-up

- `replace()` no longer applies the cache rate limit twice; it relies on the one inside `replace_bytes()`.
- `CacheRequest` and `QueryWrite` variants are no longer feature-gated, so the serialized variant order is identical for every feature set and raft logs stay readable when features change between deployments. Disabled-feature match arms use `unreachable!()`, gated variants carry `#[allow(dead_code)]`, and the order is pinned by unit tests so a future reorder fails CI instead of corrupting logs.

## Verification

- `cargo test -p hiqlite --lib --features cache,counters,dlock,listen_notify,macros,toml` — 42 passed.
- `cargo test -p hiqlite --test cluster --features cache,counters,dlock,listen_notify,macros,toml` — all tests successful (cluster, self-heal, remote-only, including the new probes).
- `cargo clippy -- -D warnings` and the no-default feature matrix — clean.
- Regression-proven: the new probes fail against a simulated non-atomic get-without-remove implementation and pass on the real one.

## Compatibility notes

The `get_remove` / `replace` API itself is additive. The enum de-gating is a deliberate breaking change requested in review: the serialized index of `ClearAll` (and the `counters`/`dlock`/`listen_notify_local` variants) in `CacheRequest` and of `RTT` in `QueryWrite` can shift between builds with different feature sets, so an upgrade to this version requires clearing the cache and starting from fresh WAL files (new minor version).

Developed with carefully directed, manually reviewed AI assistance.